### PR TITLE
fix: exclude non-canonical/auth pages from sitemap

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -34,7 +34,22 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const allRoutes = flattenRoutes(routes);
 
   // Define routes to exclude from sitemap
-  const excludedRoutes = ["/api", "/workers", "/sign-out", "/error", "/admin"];
+  const excludedRoutes = [
+    "/api",
+    "/workers",
+    "/sign-out",
+    "/sign-in",
+    "/sign-up",
+    "/error",
+    "/admin",
+    "/dashboard",
+    "/settings",
+    "/api-keys",
+    "/forgot-password",
+    "/og",
+    "/trpc",
+    "/launch",
+  ];
 
   // Filter routes
   const includedRoutes = allRoutes.filter((route) => {


### PR DESCRIPTION
Ahrefs flagged 9 non-canonical pages in the sitemap (health score 77). These are auth pages, app pages behind login, and technical endpoints that shouldn't be indexed.

Excluded: dashboard, settings, forgot-password, og, trpc, launch, sign-in, sign-up, api-keys.