### PR TITLE
feat: add 7 generic hooks from shipkit

### DIFF
--- a/src/hooks/use-async-state.ts
+++ b/src/hooks/use-async-state.ts
@@ -1,0 +1,194 @@
+import { useCallback, useState } from "react";
+
+export interface AsyncState<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+  success: boolean;
+}
+
+export interface UseAsyncStateReturn<T, Args extends unknown[]> extends AsyncState<T> {
+  execute: (...args: Args) => Promise<T>;
+  reset: () => void;
+  setData: (data: T | null) => void;
+  setError: (error: string | null) => void;
+}
+
+/**
+ * A hook for managing async operations with standardized loading, error, and success states.
+ *
+ * @example
+ * ```tsx
+ * const { data, loading, error, execute } = useAsyncState(async (id: string) => {
+ *   const response = await fetch(`/api/users/${id}`);
+ *   return response.json();
+ * });
+ *
+ * // Usage
+ * const handleSubmit = () => execute(userId);
+ * ```
+ */
+export function useAsyncState<T, Args extends unknown[]>(
+  asyncFunction: (...args: Args) => Promise<T>,
+  initialData: T | null = null
+): UseAsyncStateReturn<T, Args> {
+  const [data, setData] = useState<T | null>(initialData);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const execute = useCallback(
+    async (...args: Args): Promise<T> => {
+      setLoading(true);
+      setError(null);
+      setSuccess(false);
+
+      try {
+        const result = await asyncFunction(...args);
+        setData(result);
+        setSuccess(true);
+        return result;
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : "An unknown error occurred";
+        setError(errorMessage);
+        throw err;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [asyncFunction]
+  );
+
+  const reset = useCallback(() => {
+    setData(initialData);
+    setLoading(false);
+    setError(null);
+    setSuccess(false);
+  }, [initialData]);
+
+  return {
+    data,
+    loading,
+    error,
+    success,
+    execute,
+    reset,
+    setData,
+    setError,
+  };
+}
+
+/**
+ * A simpler version for operations that don't return data
+ */
+export function useAsyncAction<Args extends unknown[]>(
+  asyncFunction: (...args: Args) => Promise<void>
+) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const execute = useCallback(
+    async (...args: Args): Promise<void> => {
+      setLoading(true);
+      setError(null);
+      setSuccess(false);
+
+      try {
+        await asyncFunction(...args);
+        setSuccess(true);
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : "An unknown error occurred";
+        setError(errorMessage);
+        throw err;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [asyncFunction]
+  );
+
+  const reset = useCallback(() => {
+    setLoading(false);
+    setError(null);
+    setSuccess(false);
+  }, []);
+
+  return {
+    loading,
+    error,
+    success,
+    execute,
+    reset,
+    setError,
+  };
+}
+
+/**
+ * Hook for managing multiple async operations with independent states
+ */
+export function useMultiAsyncState<T extends Record<string, unknown>>() {
+  const [states, setStates] = useState<Record<keyof T, AsyncState<unknown>>>(
+    {} as Record<keyof T, AsyncState<unknown>>
+  );
+
+  const createExecutor = useCallback(
+    <K extends keyof T>(key: K, asyncFunction: () => Promise<T[K]>) => {
+      return async () => {
+        setStates((prev: Record<keyof T, AsyncState<unknown>>) => ({
+          ...prev,
+          [key]: { ...prev[key], loading: true, error: null, success: false },
+        }));
+
+        try {
+          const result = await asyncFunction();
+          setStates((prev: Record<keyof T, AsyncState<unknown>>) => ({
+            ...prev,
+            [key]: { data: result, loading: false, error: null, success: true },
+          }));
+          return result;
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : "An unknown error occurred";
+          setStates((prev: Record<keyof T, AsyncState<unknown>>) => ({
+            ...prev,
+            [key]: { ...prev[key], loading: false, error: errorMessage, success: false },
+          }));
+          throw err;
+        }
+      };
+    },
+    []
+  );
+
+  const getState = useCallback(
+    <K extends keyof T>(key: K): AsyncState<T[K]> => {
+      return (
+        (states[key] as AsyncState<T[K]>) || {
+          data: null,
+          loading: false,
+          error: null,
+          success: false,
+        }
+      );
+    },
+    [states]
+  );
+
+  const reset = useCallback(<K extends keyof T>(key?: K) => {
+    if (key) {
+      setStates((prev: Record<keyof T, AsyncState<unknown>>) => ({
+        ...prev,
+        [key]: { data: null, loading: false, error: null, success: false },
+      }));
+    } else {
+      setStates({} as Record<keyof T, AsyncState<unknown>>);
+    }
+  }, []);
+
+  return {
+    createExecutor,
+    getState,
+    reset,
+    states,
+  };
+}

--- a/src/hooks/use-auto-resize-textarea.ts
+++ b/src/hooks/use-auto-resize-textarea.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useRef } from "react";
+
+interface UseAutoResizeTextareaProps {
+  minHeight: number;
+  maxHeight?: number;
+}
+
+export function useAutoResizeTextarea({ minHeight, maxHeight }: UseAutoResizeTextareaProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const adjustHeight = useCallback(
+    (reset?: boolean) => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+
+      if (reset) {
+        textarea.style.height = `${minHeight}px`;
+        return;
+      }
+
+      // Temporarily shrink to get the right scrollHeight
+      textarea.style.height = `${minHeight}px`;
+
+      // Calculate new height
+      const newHeight = Math.max(
+        minHeight,
+        Math.min(textarea.scrollHeight, maxHeight ?? Number.POSITIVE_INFINITY)
+      );
+
+      textarea.style.height = `${newHeight}px`;
+    },
+    [minHeight, maxHeight]
+  );
+
+  useEffect(() => {
+    // Set initial height
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.style.height = `${minHeight}px`;
+    }
+  }, [minHeight]);
+
+  // Adjust height on window resize
+  useEffect(() => {
+    const handleResize = () => adjustHeight();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [adjustHeight]);
+
+  return { textareaRef, adjustHeight };
+}

--- a/src/hooks/use-auto-resize-textarea.ts
+++ b/src/hooks/use-auto-resize-textarea.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useCallback, useEffect, useRef } from "react";
 
 interface UseAutoResizeTextareaProps {

--- a/src/hooks/use-countdown.ts
+++ b/src/hooks/use-countdown.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+
+interface CountdownResult {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  isExpired: boolean;
+}
+
+/**
+ * Hook to create a countdown timer to a specific date
+ * @param targetDate - The date to count down to (ISO string or Date object)
+ * @returns CountdownResult object with remaining time and expiry status
+ */
+export const useCountdown = (targetDate: string | Date): CountdownResult => {
+  const [countdown, setCountdown] = useState<CountdownResult>({
+    days: 0,
+    hours: 0,
+    minutes: 0,
+    seconds: 0,
+    isExpired: false,
+  });
+
+  useEffect(() => {
+    const target = new Date(targetDate).getTime();
+
+    const calculateTimeLeft = () => {
+      const now = new Date().getTime();
+      const difference = target - now;
+
+      if (difference <= 0) {
+        return {
+          days: 0,
+          hours: 0,
+          minutes: 0,
+          seconds: 0,
+          isExpired: true,
+        };
+      }
+
+      return {
+        days: Math.floor(difference / (1000 * 60 * 60 * 24)),
+        hours: Math.floor((difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)),
+        minutes: Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60)),
+        seconds: Math.floor((difference % (1000 * 60)) / 1000),
+        isExpired: false,
+      };
+    };
+
+    // Defer initial setState so the effect does not synchronously cascade renders.
+    queueMicrotask(() => setCountdown(calculateTimeLeft()));
+
+    const timer = setInterval(() => {
+      setCountdown(calculateTimeLeft());
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [targetDate]);
+
+  return countdown;
+};

--- a/src/hooks/use-countdown.ts
+++ b/src/hooks/use-countdown.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from "react";
 
 interface CountdownResult {
@@ -48,11 +50,12 @@ export const useCountdown = (targetDate: string | Date): CountdownResult => {
       };
     };
 
-    // Defer initial setState so the effect does not synchronously cascade renders.
-    queueMicrotask(() => setCountdown(calculateTimeLeft()));
+    setCountdown(calculateTimeLeft());
 
     const timer = setInterval(() => {
-      setCountdown(calculateTimeLeft());
+      const result = calculateTimeLeft();
+      setCountdown(result);
+      if (result.isExpired) clearInterval(timer);
     }, 1000);
 
     return () => clearInterval(timer);

--- a/src/hooks/use-haptics.ts
+++ b/src/hooks/use-haptics.ts
@@ -1,0 +1,108 @@
+"use client";
+
+/**
+ * Web Haptics hook for ShipKit.
+ *
+ * Uses the `web-haptics` library which provides:
+ * - `navigator.vibrate()` on Android/Chrome
+ * - iOS Safari haptics via the `<input type="checkbox" switch>` trick
+ * - PWM intensity modulation for perceived vibration strength
+ * - Audio debug mode for desktop testing
+ *
+ * @see https://haptics.lochie.me
+ * @see https://github.com/lochie/web-haptics
+ */
+
+import { useMemo } from "react";
+import type { HapticInput, TriggerOptions } from "web-haptics";
+import { useWebHaptics } from "web-haptics/react";
+
+export type HapticPattern =
+  | "light"
+  | "medium"
+  | "heavy"
+  | "success"
+  | "warning"
+  | "error"
+  | "selection"
+  | "soft"
+  | "rigid"
+  | "nudge"
+  | "buzz";
+
+// Mutable store for imperative (non-hook) usage — object properties satisfy react-hooks/globals (no top-level `let` reassignment).
+const imperativeHaptics: {
+  trigger: ((input?: HapticInput, opts?: TriggerOptions) => void) | null;
+  cancel: (() => void) | null;
+} = { trigger: null, cancel: null };
+
+/**
+ * Fire a haptic vibration pattern.
+ *
+ * Safe to call unconditionally — no-ops during SSR and on
+ * unsupported devices.
+ */
+export function haptic(pattern: HapticPattern = "light"): void {
+  imperativeHaptics.trigger?.(pattern);
+}
+
+/**
+ * Cancel any ongoing haptic vibration.
+ */
+export function hapticCancel(): void {
+  imperativeHaptics.cancel?.();
+}
+
+/**
+ * React hook that returns memoised haptic helpers.
+ *
+ * Uses `web-haptics` under the hood for cross-platform support
+ * (including iOS Safari via the checkbox switch trick).
+ *
+ * ```tsx
+ * const { tap, toggle, success } = useHaptics();
+ * <Button onClick={() => { tap(); doStuff(); }} />
+ * ```
+ */
+export function useHaptics() {
+  const { trigger, cancel, isSupported } = useWebHaptics();
+
+  imperativeHaptics.trigger = trigger;
+  imperativeHaptics.cancel = cancel;
+
+  return useMemo(
+    () => ({
+      /** Light tap — general button presses */
+      tap: () => trigger("light"),
+      /** Medium pulse — switches, toggles */
+      toggle: () => trigger("medium"),
+      /** Selection tick — tabs, radio, checkbox */
+      selection: () => trigger("selection"),
+      /** Double-pulse — copy, save, success */
+      success: () => trigger("success"),
+      /** Warning burst */
+      warning: () => trigger("warning"),
+      /** Error buzz */
+      error: () => trigger("error"),
+      /** Heavy thud — destructive / confirm */
+      heavy: () => trigger("heavy"),
+      /** Soft cushioned tap */
+      soft: () => trigger("soft"),
+      /** Hard crisp tap */
+      rigid: () => trigger("rigid"),
+      /** Reminder nudge */
+      nudge: () => trigger("nudge"),
+      /** Long buzz */
+      buzz: () => trigger("buzz"),
+      /** Cancel current vibration */
+      cancel,
+      /** Whether the device supports haptics */
+      isSupported,
+      /** Raw trigger — pass any HapticInput */
+      trigger,
+      /** Legacy pattern access (calls trigger internally) */
+      haptic,
+    }),
+    [trigger, cancel, isSupported]
+  );
+}

--- a/src/hooks/use-has-primary-touch.tsx
+++ b/src/hooks/use-has-primary-touch.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+export function useTouchPrimary() {
+  const [isTouchPrimary, setIsTouchPrimary] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    const handleTouch = () => {
+      const hasTouch = "ontouchstart" in window || navigator.maxTouchPoints > 0;
+      const prefersTouch = window.matchMedia("(pointer: coarse)").matches;
+      setIsTouchPrimary(hasTouch && prefersTouch);
+    };
+
+    const mq = window.matchMedia("(pointer: coarse)");
+    mq.addEventListener("change", handleTouch, { signal });
+    window.addEventListener("pointerdown", handleTouch, { signal });
+
+    handleTouch();
+
+    return () => controller.abort();
+  }, []);
+
+  return isTouchPrimary;
+}

--- a/src/hooks/use-has-primary-touch.tsx
+++ b/src/hooks/use-has-primary-touch.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 import { useEffect, useState } from "react";
 
-export function useTouchPrimary() {
+export function useHasPrimaryTouch() {
   const [isTouchPrimary, setIsTouchPrimary] = useState(false);
 
   useEffect(() => {

--- a/src/hooks/use-is-mac.ts
+++ b/src/hooks/use-is-mac.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { is } from "@/lib/utils/is";
+
+// Extend Navigator type to include userAgentData (might be browser-specific)
+interface NavigatorWithUAData extends Navigator {
+  userAgentData?: {
+    platform: string;
+    brands: { brand: string; version: string }[];
+    mobile: boolean;
+  };
+}
+
+/**
+ * Hook to determine if the current OS is macOS.
+ * Uses navigator.userAgentData if available, otherwise falls back to navigator.platform.
+ * Returns false during SSR or if the platform cannot be determined.
+ */
+export function useIsMac(): boolean {
+  const [isMac, setIsMac] = useState(false);
+
+  useEffect(() => {
+    let determinedIsMac = false;
+    if (typeof window !== "undefined") {
+      const nav = navigator as NavigatorWithUAData; // Cast to extended type
+
+      // Prefer userAgentData if available
+      if (nav.userAgentData?.platform) {
+        determinedIsMac = /mac|iphone|ipad|ipod/i.test(nav.userAgentData.platform);
+      } else if (nav.platform) {
+        // Fallback to platform
+        determinedIsMac = /Mac|iPod|iPhone|iPad/.test(nav.platform);
+      } else {
+        // Last resort fallback using the existing utility
+        determinedIsMac = is.mac;
+      }
+    }
+    queueMicrotask(() => setIsMac(determinedIsMac));
+  }, []);
+
+  return isMac;
+}

--- a/src/hooks/use-is-mac.ts
+++ b/src/hooks/use-is-mac.ts
@@ -33,7 +33,7 @@ export function useIsMac(): boolean {
         determinedIsMac = /Mac|iPod|iPhone|iPad/.test(nav.platform);
       } else {
         // Last resort fallback using the existing utility
-        determinedIsMac = is.mac;
+        determinedIsMac = is.mac();
       }
     }
     setIsMac(determinedIsMac);

--- a/src/hooks/use-is-mac.ts
+++ b/src/hooks/use-is-mac.ts
@@ -36,7 +36,7 @@ export function useIsMac(): boolean {
         determinedIsMac = is.mac;
       }
     }
-    queueMicrotask(() => setIsMac(determinedIsMac));
+    setIsMac(determinedIsMac);
   }, []);
 
   return isMac;

--- a/src/hooks/use-local-storage.ts
+++ b/src/hooks/use-local-storage.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T
+): [T, (value: T | ((val: T) => T)) => void] {
+  // Get from local storage then
+  // parse stored json or return initialValue
+  const readValue = (): T => {
+    // Prevent build error "window is undefined" but keep working
+    if (typeof window === "undefined") {
+      return initialValue;
+    }
+
+    try {
+      const item = window.localStorage.getItem(key);
+      if (!item) return initialValue;
+      const parsed = JSON.parse(item) as T;
+      // Handle case where localStorage contains "null" or invalid data
+      return parsed ?? initialValue;
+    } catch (error) {
+      console.warn(`Error reading localStorage key "${key}":`, error);
+      return initialValue;
+    }
+  };
+
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(readValue);
+
+  // Stable setter that updates state; localStorage sync happens in an effect
+  const setValue = useCallback(
+    (value: T | ((val: T) => T)) => {
+      try {
+        setStoredValue((prev) =>
+          value instanceof Function ? (value as (val: T) => T)(prev) : value
+        );
+      } catch (error) {
+        console.warn(`Error setting localStorage key "${key}":`, error);
+      }
+    },
+    [key]
+  );
+
+  useEffect(() => {
+    setStoredValue(readValue());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  useEffect(() => {
+    const handleStorageChange = (event: StorageEvent) => {
+      if (event.key === key) {
+        // Handle null value (item was removed)
+        if (event.newValue === null) {
+          setStoredValue(initialValue);
+          return;
+        }
+
+        // Safely parse the new value with error handling
+        try {
+          const parsedValue = JSON.parse(event.newValue) as T;
+          setStoredValue(parsedValue);
+        } catch (error) {
+          console.warn(`Error parsing localStorage change for key "${key}":`, error);
+          // If parsing fails, try to read directly from localStorage
+          // This handles edge cases where the event data might be corrupted
+          try {
+            const item = window.localStorage.getItem(key);
+            if (item !== null) {
+              const fallbackValue = JSON.parse(item) as T;
+              setStoredValue(fallbackValue);
+            } else {
+              setStoredValue(initialValue);
+            }
+          } catch (fallbackError) {
+            console.warn(`Fallback parsing also failed for key "${key}":`, fallbackError);
+            setStoredValue(initialValue);
+          }
+        }
+      }
+    };
+
+    // Listen for changes to this local storage key in other tabs/windows
+    window.addEventListener("storage", handleStorageChange);
+    return () => {
+      window.removeEventListener("storage", handleStorageChange);
+    };
+  }, [key, initialValue]);
+
+  // Persist to localStorage whenever value or key changes
+  useEffect(() => {
+    try {
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(key, JSON.stringify(storedValue));
+      }
+    } catch (error) {
+      console.warn(`Error persisting localStorage key "${key}":`, error);
+    }
+  }, [key, storedValue]);
+
+  return [storedValue, setValue];
+}


### PR DESCRIPTION
## Summary
- Add 7 generic React hooks backfilled from shipkit
- `use-async-state`, `use-auto-resize-textarea`, `use-countdown`, `use-haptics`, `use-has-primary-touch`, `use-is-mac`, `use-local-storage`
- All hooks are generic utilities with no premium dependencies

## Dependencies
- `use-haptics` requires `web-haptics` package (added in #15)
- `use-is-mac` uses existing `@/lib/utils/is` utility

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] Hooks can be imported and used in components

🤖 Generated with [Claude Code](https://claude.com/claude-code)