### PR TITLE
fix: add unique constraint to user email

### DIFF
--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -84,7 +84,7 @@ export const users = createTable("user", {
 		.primaryKey()
 		.$defaultFn(() => crypto.randomUUID()),
 	name: varchar("name", { length: 255 }),
-	email: varchar("email", { length: 255 }).notNull(),
+	email: varchar("email", { length: 255 }).notNull().unique(),
 	emailVerified: timestamp("email_verified", {
 		mode: "date",
 		withTimezone: true,


### PR DESCRIPTION
## Summary
- Add `.unique()` constraint to the `email` field on the `users` table
- Enforces email uniqueness at the database level, matching the shipkit schema

## Migration note
Existing databases with duplicate emails will need deduplication before applying this migration. Run `db:generate` then `db:migrate` after merging.

## Test plan
- [ ] `pnpm db:generate` creates the migration
- [ ] `pnpm db:migrate` applies successfully (on clean DB)
- [ ] Attempting to insert duplicate emails is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)