### PR TITLE
fix: address review issues from backfill PRs

### DIFF
--- a/src/components/buttons/animated-button/animated-button.tsx
+++ b/src/components/buttons/animated-button/animated-button.tsx
@@ -70,4 +70,4 @@ const AnimatedButton: React.FC<AnimatedButtonProps> = ({
 	);
 };
 
-export default AnimatedButton;
+export { AnimatedButton };

--- a/src/components/ui/animated-gradient-text.tsx
+++ b/src/components/ui/animated-gradient-text.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 
-export default function AnimatedGradientText({
+export function AnimatedGradientText({
   children,
   className,
 }: {

--- a/src/components/ui/animated-shiny-text.tsx
+++ b/src/components/ui/animated-shiny-text.tsx
@@ -37,4 +37,4 @@ const AnimatedShinyText: FC<AnimatedShinyTextProps> = ({
   );
 };
 
-export default AnimatedShinyText;
+export { AnimatedShinyText };

--- a/src/components/ui/avatar-circles.tsx
+++ b/src/components/ui/avatar-circles.tsx
@@ -31,4 +31,4 @@ const AvatarCircles = ({ numPeople, className, avatarUrls }: AvatarCirclesProps)
   );
 };
 
-export default AvatarCircles;
+export { AvatarCircles };

--- a/src/components/ui/blur-fade.tsx
+++ b/src/components/ui/blur-fade.tsx
@@ -26,7 +26,7 @@ interface BlurFadeProps {
   blur?: string;
 }
 
-export default function BlurFade({
+export function BlurFade({
   children,
   className,
   variant,

--- a/src/components/ui/code-window.tsx
+++ b/src/components/ui/code-window.tsx
@@ -155,9 +155,10 @@ export const CodeWindow = ({
       <div
         className={cn(
           codeContentVariants({ variant }),
-          !isExpanded && !isSingle && `max-h-[${maxHeight}]`,
+          !isExpanded && !isSingle && "overflow-y-auto",
           "group relative"
         )}
+        style={{ maxHeight: isExpanded || isSingle ? undefined : maxHeight }}
       >
         <SyntaxHighlighter
           language={language}

--- a/src/components/ui/particles.tsx
+++ b/src/components/ui/particles.tsx
@@ -74,6 +74,7 @@ export const Particles: React.FC<ParticlesProps> = ({
   const canvasContainerRef = useRef<HTMLDivElement>(null);
   const context = useRef<CanvasRenderingContext2D | null>(null);
   const circles = useRef<Circle[]>([]);
+  const animationFrameRef = useRef<number>(0);
   const mousePosition = MousePosition();
   const mouse = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
   const canvasSize = useRef<{ w: number; h: number }>({ w: 0, h: 0 });
@@ -90,6 +91,7 @@ export const Particles: React.FC<ParticlesProps> = ({
 
     return () => {
       window.removeEventListener("resize", initCanvas);
+      cancelAnimationFrame(animationFrameRef.current);
     };
   }, [color]);
 
@@ -259,7 +261,7 @@ export const Particles: React.FC<ParticlesProps> = ({
         // update the circle position
       }
     });
-    window.requestAnimationFrame(animate);
+    animationFrameRef.current = window.requestAnimationFrame(animate);
   };
 
   return (

--- a/src/components/ui/share.tsx
+++ b/src/components/ui/share.tsx
@@ -2,6 +2,7 @@
 
 import { Facebook, Linkedin, Link as LinkIcon, Share2, Twitter } from "lucide-react";
 import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -31,6 +32,11 @@ export const Share = ({
   const { toast } = useToast();
   const pathname = usePathname();
   const url = `${BASE_URL}${pathname}`;
+  const [supportsNativeShare, setSupportsNativeShare] = useState(false);
+
+  useEffect(() => {
+    setSupportsNativeShare(typeof navigator?.share === "function");
+  }, []);
 
   const shareData = {
     title,
@@ -99,7 +105,7 @@ export const Share = ({
           <Share2 className="h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>
-      {!navigator?.share && (
+      {!supportsNativeShare && (
         <DropdownMenuContent align="end">
           <DropdownMenuItem onClick={() => openShareWindow(twitterUrl)}>
             <Twitter className="mr-2 h-4 w-4" />

--- a/src/components/ui/shooting-stars.tsx
+++ b/src/components/ui/shooting-stars.tsx
@@ -57,6 +57,7 @@ export const ShootingStars: React.FC<ShootingStarsProps> = ({
   const svgRef = useRef<SVGSVGElement>(null);
 
   useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>;
     const createStar = () => {
       const { x, y, angle } = getRandomStartPoint();
       const newStar: ShootingStar = {
@@ -71,12 +72,12 @@ export const ShootingStars: React.FC<ShootingStarsProps> = ({
       setStar(newStar);
 
       const randomDelay = Math.random() * (maxDelay - minDelay) + minDelay;
-      setTimeout(createStar, randomDelay);
+      timeoutId = setTimeout(createStar, randomDelay);
     };
 
     createStar();
 
-    return () => {};
+    return () => clearTimeout(timeoutId);
   }, [minSpeed, maxSpeed, minDelay, maxDelay]);
 
   useEffect(() => {

--- a/src/components/ui/vercel-navigation.tsx
+++ b/src/components/ui/vercel-navigation.tsx
@@ -109,4 +109,3 @@ export const VercelNavigation = ({
 	);
 };
 
-export default VercelNavigation;

--- a/src/config/secrets.ts
+++ b/src/config/secrets.ts
@@ -17,6 +17,13 @@ export function getMasterAppSecret(): string {
     return provided;
   }
 
+  if (process.env.NODE_ENV === "production") {
+    console.warn(
+      "[SECURITY] APP_SECRET is not set. Using deterministic fallback derived from BASE_URL. " +
+        "This is INSECURE for production. Set APP_SECRET in your environment."
+    );
+  }
+
   const input = `${BASE_URL}|bones|app-secret|v1`;
   return crypto.createHash("sha256").update(input).digest("hex");
 }

--- a/src/hooks/use-async-state.ts
+++ b/src/hooks/use-async-state.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 export interface AsyncState<T> {
   data: T | null;
@@ -36,24 +36,32 @@ export function useAsyncState<T, Args extends unknown[]>(
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const requestIdRef = useRef(0);
 
   const execute = useCallback(
     async (...args: Args): Promise<T> => {
+      const currentId = ++requestIdRef.current;
       setLoading(true);
       setError(null);
       setSuccess(false);
 
       try {
         const result = await asyncFunction(...args);
-        setData(result);
-        setSuccess(true);
+        if (currentId === requestIdRef.current) {
+          setData(result);
+          setSuccess(true);
+        }
         return result;
       } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : "An unknown error occurred";
-        setError(errorMessage);
+        if (currentId === requestIdRef.current) {
+          const errorMessage = err instanceof Error ? err.message : "An unknown error occurred";
+          setError(errorMessage);
+        }
         throw err;
       } finally {
-        setLoading(false);
+        if (currentId === requestIdRef.current) {
+          setLoading(false);
+        }
       }
     },
     [asyncFunction]

--- a/src/hooks/use-local-storage.ts
+++ b/src/hooks/use-local-storage.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export function useLocalStorage<T>(
   key: string,
@@ -89,8 +89,14 @@ export function useLocalStorage<T>(
     };
   }, [key, initialValue]);
 
-  // Persist to localStorage whenever value or key changes
+  // Persist to localStorage whenever value changes via setValue
+  const isInitialMount = useRef(true);
   useEffect(() => {
+    // Skip the initial mount to avoid writing the default value
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
     try {
       if (typeof window !== "undefined") {
         window.localStorage.setItem(key, JSON.stringify(storedValue));

--- a/src/lib/trpc/react.tsx
+++ b/src/lib/trpc/react.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/src/lib/utils/debounce.ts
+++ b/src/lib/utils/debounce.ts
@@ -1,15 +1,8 @@
-// @ts-nocheck
-/* eslint-disable-all */
-
-// Remove the import statement for Timeout
-// import { Timeout } from 'node';
-
-// Add a type annotation for startIndex
-export function restArguments<T extends any[], R>(
-	func: (...args: [...T, ...R[]]) => any,
+export function restArguments<F extends (...args: unknown[]) => unknown>(
+	func: F,
 	startIndex: number = func.length - 1
 ) {
-	return function (this: any, ...args: T) {
+	return function (this: unknown, ...args: unknown[]) {
 		const length = Math.max(args.length - startIndex, 0);
 		const rest = Array(length);
 		let index = 0;
@@ -18,25 +11,24 @@ export function restArguments<T extends any[], R>(
 		}
 		switch (startIndex) {
 			case 0:
-				return func.call(this, rest) as R;
+				return func.call(this, rest);
 			case 1:
-				return func.call(this, args[0], rest) as R;
+				return func.call(this, args[0], rest);
 			case 2:
-				return func.call(this, args[0], args[1], rest) as R;
+				return func.call(this, args[0], args[1], rest);
 			default: {
-				const _args: [...T, R[]] = Array(startIndex + 1) as [...T, R[]];
+				const _args = Array(startIndex + 1);
 				for (index = 0; index < startIndex; index += 1) {
 					_args[index] = args[index];
 				}
 				_args[startIndex] = rest;
-				return func.apply(this, _args) as R;
+				return func.apply(this, _args);
 			}
 		}
 	};
 }
 
-// Add type annotation for this
-export function debounce<T extends any[], R>(
+export function debounce<T extends unknown[], R>(
 	func: (...args: T) => R,
 	wait: number,
 	immediate?: boolean
@@ -45,11 +37,11 @@ export function debounce<T extends any[], R>(
 	let previous: number;
 	let args: T | undefined;
 	let result: R | undefined;
-	let context: any;
+	let context: unknown;
 
 	const now = () => Date.now();
 
-	const later = function (this: any) {
+	const later = function () {
 		const passed = now() - previous;
 		if (wait > passed) {
 			timeout = setTimeout(later, wait - passed);
@@ -59,15 +51,15 @@ export function debounce<T extends any[], R>(
 				result = func.apply(context, args!);
 			}
 			if (!timeout) {
-				args = context = undefined;
+				args = undefined;
+				context = undefined;
 			}
 		}
 	};
 
-	const debounced = restArguments(function (this: any, _args: T) {
-		// eslint-disable-next-line @typescript-eslint/no-this-alias
+	const debounced = restArguments(function (this: unknown, _args: unknown) {
 		context = this;
-		args = _args;
+		args = _args as T;
 		previous = now();
 		if (!timeout) {
 			timeout = setTimeout(later, wait);
@@ -78,11 +70,12 @@ export function debounce<T extends any[], R>(
 		return result;
 	});
 
-	// Add cancel property
-	debounced.cancel = function (this: any) {
-		clearTimeout(timeout!);
-		timeout = args = context = undefined;
+	(debounced as typeof debounced & { cancel: () => void }).cancel = function () {
+		if (timeout) clearTimeout(timeout);
+		timeout = null;
+		args = undefined;
+		context = undefined;
 	};
 
-	return debounced;
+	return debounced as typeof debounced & { cancel: () => void };
 }


### PR DESCRIPTION
## Summary

Fixes all issues identified during code review of the 6 backfill PRs (#15-#20):

- **Memory leaks**: Fix animation frame leak in `particles.tsx` and setTimeout leak in `shooting-stars.tsx` — both now properly clean up on unmount
- **Security**: Add production warning when `APP_SECRET` falls back to deterministic derivation from `BASE_URL` in `secrets.ts`
- **SSR/Hydration**: Fix `share.tsx` hydration mismatch — `navigator.share` check moved from render-time to `useEffect`
- **Tailwind purge**: Fix `code-window.tsx` dynamic class `max-h-[${maxHeight}]` — replaced with inline `style` prop
- **Race condition**: Add request counter guard to `use-async-state.ts` to discard stale async results
- **localStorage pollution**: Fix `use-local-storage.ts` writing `initialValue` on mount — now skips initial render
- **Named exports**: Convert 6 components from `export default` to named exports per project convention
- **Type safety**: Remove `@ts-nocheck` from `debounce.ts` and `trpc/react.tsx`, add proper types

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes with clean output
- [ ] Verify particles animation stops when navigating away from page
- [ ] Verify share dropdown renders consistently between server and client

🤖 Generated with [Claude Code](https://claude.com/claude-code)