### PR TITLE
chore(release): bump bones to v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+## v0.2.2 - 2026-05-15
+
+- feat: backfill 63 UI components from shipkit
+- feat: backfill 7 generic hooks from shipkit
+- feat: backfill faq, changelog, contact, feedback, email, analytics free blocks
+- fix(auth): await OAuth server action to fix redirect handling
+- fix: update deploy button with working demo URL and accurate metadata
+- fix: use webpack for Vercel builds (Turbopack crashes on v16.1.6)
+- fix: add unique constraint to user email in schema
+- fix: resolve cross-PR import dependencies
+- chore: sync shared infra from ShipKit
+
+## v0.2.1 - 2025-09-23
+
+- Maintenance: version bump to align internal `shipkit.bones`
+- Various improvements and docs updates since last tag

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "bones",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "homepage": "https://bones.sh",
   "repository": {
     "type": "git",
     "url": "https://github.com/shipkit-io/bones"
   },
   "shipkit": {
-    "bones": "0.2.1"
+    "bones": "0.2.2"
   },
   "license": "AGPL-3.0-only",
   "private": true,


### PR DESCRIPTION
## Summary

- Bumps `version` in `package.json` from `0.2.1` → `0.2.2`
- Updates `shipkit.bones` tracking field to `0.2.2`
- Adds `CHANGELOG.md` with `v0.2.2` entry capturing all changes since `v0.2.1`

Closes: https://app.paperclip.software/issues/LAC-1472

## Changes since v0.2.1

- feat: backfill 63 UI components from shipkit
- feat: backfill 7 generic hooks from shipkit
- feat: backfill faq, changelog, contact, feedback, email, analytics free blocks
- fix(auth): await OAuth server action to fix redirect handling
- fix: update deploy button with working demo URL and accurate metadata
- fix: use webpack for Vercel builds (Turbopack crashes on v16.1.6)
- fix: add unique constraint to user email in schema
- chore: sync shared infra from ShipKit

## Test plan

- [ ] Verify `package.json` version reads `0.2.2`
- [ ] Verify CHANGELOG.md is present and accurate