### PR TITLE
fix(seo): canonical URLs and demo noindex

### DIFF
--- a/src/app/(app)/(demo)/layout.tsx
+++ b/src/app/(app)/(demo)/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+import type React from "react";
+
+export const metadata: Metadata = {
+	robots: { index: false, follow: false },
+};
+
+export default function DemoLayout({ children }: { children: React.ReactNode }) {
+	return <>{children}</>;
+}

--- a/src/app/(app)/faq/page.tsx
+++ b/src/app/(app)/faq/page.tsx
@@ -1,13 +1,17 @@
 import { notFound } from "next/navigation";
+import type { Metadata } from "next";
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { routeMetadata } from "@/config/metadata";
 import { siteConfig } from "@/config/site-config";
 import { getPayloadContent } from "@/lib/utils/get-payload-content";
 import type { Faq } from "@/payload-types";
+
+export const metadata: Metadata = routeMetadata.faq;
 
 // Define types for static content structure
 type StaticFaq = {

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -4,11 +4,14 @@ import {
   PageHeaderDescription,
   PageHeaderHeading,
 } from "@/components/primitives/page-header";
+import { JsonLd } from "@/components/primitives/json-ld";
 import { Attribution } from "@/components/ui/attribution";
 import { buttonVariants } from "@/components/ui/button";
 import { TextLoop } from "@/components/ui/text-loop";
 import { routes } from "@/config/routes";
+import { routeMetadata } from "@/config/metadata";
 import { cn } from "@/lib/utils";
+import type { Metadata } from "next";
 import { IconBrandGithub } from "@tabler/icons-react";
 import { Space_Grotesk } from "next/font/google";
 import Link from "next/link";
@@ -20,9 +23,12 @@ const font = Space_Grotesk({
   variable: "--font-space-grotesk",
 });
 
+export const metadata: Metadata = routeMetadata.home;
+
 export default function Page() {
   return (
     <>
+      <JsonLd organization website softwareSourceCode />
       <div className="container flex flex-col items-center justify-center gap-2xl py-6 text-center min-h-screen">
         <PageHeader className="flex flex-col items-center justify-center">
           <PageHeaderHeading

--- a/src/components/primitives/json-ld.tsx
+++ b/src/components/primitives/json-ld.tsx
@@ -1,4 +1,3 @@
-import Script from "next/script";
 import { siteConfig } from "@/config/site-config";
 
 interface JsonLdProps {
@@ -199,8 +198,10 @@ export function JsonLd({
 	};
 
 	return (
-		<Script id="json-ld" type="application/ld+json" strategy="lazyOnload">
-			{`${JSON.stringify(structuredData)}`}
-		</Script>
+		<script
+			type="application/ld+json"
+			// biome-ignore lint/security/noDangerouslySetInnerHtml: structured data must be inline for SEO
+			dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+		/>
 	);
 }

--- a/src/config/metadata.ts
+++ b/src/config/metadata.ts
@@ -173,4 +173,14 @@ export const routeMetadata = {
 		description:
 			`Comprehensive guides, API references, and examples to help you build production-ready apps with ${siteConfig.branding.projectName}. From quick starts to advanced topics.`,
 	},
+	faq: {
+		title: `FAQ - Frequently Asked Questions | ${siteConfig.branding.projectName}`,
+		description:
+			`Answers to common questions about ${siteConfig.branding.projectName}. Get help with setup, pricing, features, and more.`,
+	},
+	contact: {
+		title: `Contact Us | ${siteConfig.branding.projectName}`,
+		description:
+			`Get in touch with the ${siteConfig.branding.projectName} team. We're here to help with questions, feedback, and support.`,
+	},
 };

--- a/src/config/metadata.ts
+++ b/src/config/metadata.ts
@@ -75,7 +75,7 @@ export const defaultMetadata: Metadata = {
 	// 	yandex: "your-yandex-verification",
 	// },
 	alternates: {
-		canonical: siteConfig.url,
+		canonical: "./",
 		// languages: {
 		// 	"en-US": "/en-US",
 		// },


### PR DESCRIPTION
## Summary

Template-level SEO improvements for bones (upstream). All downstream sites inherit these.

### Commits

1. **fix(seo): canonical URLs** — Changed hardcoded homepage URL to `./` so Next.js resolves per-page canonicals (cherry-picked from shipkit 2c785205)
2. **fix(seo): noindex demo routes** — Added `robots: noindex` layout to `(demo)` group
3. **feat(seo): structured data + metadata** — JsonLd renders synchronously (not lazy), wired on homepage; metadata exports on homepage and FAQ; expanded `routeMetadata` with faq/contact entries

## Context

Board directed all template-level SEO fixes to `bones` upstream so all downstream sites inherit. See LAC-233.

## Test plan
- [ ] Non-homepage `<link rel="canonical">` resolves to the page's own URL
- [ ] `/trpc` returns `<meta name="robots" content="noindex, nofollow">`
- [ ] Homepage HTML contains `<script type="application/ld+json">` inline (not deferred)
- [ ] Homepage `<title>` uses `routeMetadata.home.title`
- [ ] `bun run build` passes with no type errors