### PR TITLE
feat(seo): add charset, /about page, and unique metadata for all routes

### DIFF
--- a/src/app/(app)/(legal)/eula/page.mdx
+++ b/src/app/(app)/(legal)/eula/page.mdx
@@ -1,3 +1,8 @@
+export const metadata = {
+  title: "End User License Agreement",
+  description: "EULA for our software integrations. Read the license terms, restrictions, and your rights as a user.",
+}
+
 # End User License Agreement (EULA) for Vercel Shipkit Integration
 
 Last updated: 2024-07-01

--- a/src/app/(app)/(legal)/privacy-policy/page.mdx
+++ b/src/app/(app)/(legal)/privacy-policy/page.mdx
@@ -1,85 +1,104 @@
+export const metadata = {
+  title: "Privacy Policy",
+  description: "How we handle your data. Our commitment to transparency, security, and your privacy rights.",
+}
+
 # Privacy Policy
 
-Last Updated: [Current Date]
+Last Updated: January 2025
 
 ## 1. Introduction
 
-This Privacy Policy outlines our approach to data handling, which we've made deliberately vague to accommodate our evolving interpretation of "privacy" in the digital age. While we implement reasonable measures to protect your data, we acknowledge that true privacy in today's interconnected world is largely aspirational.
+This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use our services. Please read this policy carefully. By using our services, you consent to the data practices described here.
 
-## 2. Information Collection
-
-We collect various types of information through means that may or may not be obvious to you, including:
+## 2. Information We Collect
 
 ### 2.1 Account Information
 
-- Email addresses
-- Names or identifiers
-- Profile information
-- Any additional information you voluntarily provide (which we assume means you're comfortable sharing it)
+When you create an account, we collect:
+
+- Email address
+- Name or display name
+- Profile information you choose to provide
 
 ### 2.2 Authentication Data
 
-We integrate with third-party authentication providers because building our own authentication system would require a level of responsibility we're not prepared to assume.
+We use third-party authentication providers (such as GitHub, Google, or email/password) to verify your identity. We store only the minimum data needed to maintain your session.
 
 ### 2.3 Usage Data
 
-We collect standard analytics data, which means whatever our analytics providers decide to track this week.
+We automatically collect:
+
+- Pages visited and features used
+- Browser type and device information
+- IP address and approximate location
+- Referring URLs and search terms
 
 ### 2.4 Payment Information
 
-Handled by third parties because financial responsibility is best delegated to those with proper insurance.
+Payment processing is handled by our third-party payment provider. We do not store credit card numbers or full payment details on our servers.
 
-## 3. Data Usage
+## 3. How We Use Your Information
 
-We use your information in ways that seem reasonable to us at the time, which may include:
+We use collected information to:
 
-- Service provision
-- Feature development
-- Analytics
-- Whatever else we think of later
+- Provide, maintain, and improve our services
+- Process transactions and send related information
+- Send administrative messages and service updates
+- Respond to support requests
+- Monitor usage patterns to improve user experience
+- Protect against unauthorized access and abuse
 
 ## 4. Information Sharing
 
-Your information may be shared with:
+We do not sell your personal information. We may share data with:
 
-- Service providers
-- Analytics platforms
-- Anyone we're legally compelled to share it with
-- Whoever our current or future business partners might be
+- **Service providers** who assist in operating our platform (hosting, analytics, email)
+- **Legal authorities** when required by law or to protect rights and safety
+- **Business transfers** in connection with a merger, acquisition, or sale of assets
 
 ## 5. Data Security
 
-While we implement industry-standard security measures, we acknowledge that "industry-standard" is a conveniently flexible term. Your data is as secure as current technology allows, which history suggests isn't very secure at all.
+We implement industry-standard security measures including encryption in transit (TLS), secure storage, and access controls. However, no method of electronic transmission or storage is completely secure.
 
 ## 6. Your Rights
 
-You have various rights regarding your data, though exercising them may require more persistence than you're willing to invest.
+Depending on your location, you may have the right to:
+
+- Access your personal data
+- Correct inaccurate data
+- Request deletion of your data
+- Object to or restrict processing
+- Export your data in a portable format
+
+To exercise these rights, contact us at the email below.
 
 ## 7. Data Retention
 
-We retain data for as long as we find it useful or until we run out of storage space, whichever comes first.
+We retain your data for as long as your account is active or as needed to provide services. You may request deletion at any time. Some data may be retained as required by law or legitimate business purposes.
 
-## 8. International Transfers
+## 8. Cookies and Tracking
 
-Your data will probably cross more borders than you do. By using our services, you're accepting that your data will be stored wherever our servers happen to be.
+We use essential cookies for authentication and preferences. We use analytics tools to understand how our services are used. You can manage cookie preferences through your browser settings.
 
-## 9. Changes
+## 9. International Transfers
 
-This policy will change. We'll probably notify you, but you probably won't read it.
+Your data may be processed in countries other than your own. We ensure appropriate safeguards are in place for international data transfers.
 
-## 10. Contact
+## 10. Children's Privacy
 
-For privacy concerns:
+Our services are not directed to individuals under 13. We do not knowingly collect data from children under 13.
+
+## 11. Changes to This Policy
+
+We may update this policy periodically. We will notify you of material changes by posting the new policy on this page with an updated revision date.
+
+## 12. Contact
+
+For privacy-related questions or requests:
+
 Email: privacy@shipkit.io
-Response time: Variable
-
-## Important Disclaimers
-
-- This policy is intentionally written to be both compliant and noncommittal
-- We make no guarantees about data privacy beyond what's legally required
-- The internet is inherently public, and we suggest treating it as such
-- If you're looking for absolute privacy, we recommend writing your thoughts in a journal and burying it in your backyard
 
 ---
 
-By using our Services, you acknowledge that privacy is more of a guideline than a guarantee in the digital age.
+By using our services, you acknowledge that you have read and understood this Privacy Policy.

--- a/src/app/(app)/(legal)/terms-of-service/page.mdx
+++ b/src/app/(app)/(legal)/terms-of-service/page.mdx
@@ -1,3 +1,8 @@
+export const metadata = {
+  title: "Terms of Service",
+  description: "Terms and conditions for using our services. Read our service agreement, usage policies, and your rights.",
+}
+
 # Terms of Service
 
 Last updated: 2025-01-01

--- a/src/app/(app)/about/page.tsx
+++ b/src/app/(app)/about/page.tsx
@@ -1,0 +1,74 @@
+import type { Metadata } from "next";
+import { Link } from "@/components/primitives/link";
+import { constructMetadata, routeMetadata } from "@/config/metadata";
+import { routes } from "@/config/routes";
+import { siteConfig } from "@/config/site-config";
+
+export const metadata: Metadata = constructMetadata(routeMetadata.about);
+
+export default function AboutPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-20">
+      <h1 className="mb-6 text-4xl font-bold tracking-tight">
+        About {siteConfig.branding.projectName}
+      </h1>
+
+      <section className="mb-10">
+        <p className="mb-4 text-lg text-muted-foreground">
+          {siteConfig.branding.projectName} is a modern development platform
+          built for teams and individuals who want to ship production-ready apps
+          without the boilerplate. We handle the infrastructure so you can focus
+          on what makes your product unique.
+        </p>
+        <p className="text-muted-foreground">
+          Built with Next.js, TypeScript, and the tools developers already know
+          and love &mdash; Tailwind CSS, shadcn/ui, Drizzle ORM, and more.
+        </p>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="mb-4 text-2xl font-semibold">Our Mission</h2>
+        <p className="text-muted-foreground">
+          We believe shipping software should be fast, repeatable, and enjoyable.
+          Our goal is to eliminate the weeks of setup that come before you can
+          write your first line of business logic.
+        </p>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="mb-4 text-2xl font-semibold">Built By</h2>
+        <p className="text-muted-foreground">
+          Created and maintained by{" "}
+          <Link
+            href={siteConfig.creator.url}
+            className="text-foreground underline underline-offset-4"
+          >
+            {siteConfig.creator.fullName}
+          </Link>
+          , {siteConfig.creator.bio}
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold">Get in Touch</h2>
+        <p className="text-muted-foreground">
+          Have questions or want to learn more?{" "}
+          <Link
+            href={routes.contact}
+            className="text-foreground underline underline-offset-4"
+          >
+            Contact us
+          </Link>{" "}
+          or find us on{" "}
+          <Link
+            href={siteConfig.links.github}
+            className="text-foreground underline underline-offset-4"
+          >
+            GitHub
+          </Link>
+          .
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/components/layouts/root-layout.tsx
+++ b/src/components/layouts/root-layout.tsx
@@ -10,7 +10,6 @@ import {
   Space_Grotesk as FontSans,
   Noto_Serif as FontSerif,
 } from "next/font/google";
-import Head from "next/head";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import type { ReactNode } from "react";
 
@@ -32,11 +31,10 @@ const fontSans = FontSans({
 export function RootLayout({ children }: { children: ReactNode }) {
   return (
     <ViewTransitions>
-      <Head>
-        {/* React Scan */}
-        <script src="https://unpkg.com/react-scan/dist/auto.global.js" async />
-      </Head>
       <html lang="en" suppressHydrationWarning>
+        <head>
+          <meta charSet="utf-8" />
+        </head>
         <body
           className={cn(
             "min-h-screen antialiased",

--- a/src/config/metadata.ts
+++ b/src/config/metadata.ts
@@ -183,4 +183,24 @@ export const routeMetadata = {
 		description:
 			`Get in touch with the ${siteConfig.branding.projectName} team. We're here to help with questions, feedback, and support.`,
 	},
+	about: {
+		title: `About | ${siteConfig.branding.projectName}`,
+		description:
+			`Learn about ${siteConfig.branding.projectName}, our mission, and the team behind the platform. Building modern tools for developers who ship fast.`,
+	},
+	privacy: {
+		title: `Privacy Policy | ${siteConfig.branding.projectName}`,
+		description:
+			`How ${siteConfig.branding.projectName} handles your data. Our commitment to transparency, security, and your privacy rights.`,
+	},
+	terms: {
+		title: `Terms of Service | ${siteConfig.branding.projectName}`,
+		description:
+			`Terms and conditions for using ${siteConfig.branding.projectName}. Read our service agreement, usage policies, and your rights.`,
+	},
+	changelog: {
+		title: `Changelog | ${siteConfig.branding.projectName}`,
+		description:
+			`Latest updates, improvements, and releases for ${siteConfig.branding.projectName}. See what's new and what's coming next.`,
+	},
 };

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -30,6 +30,7 @@ export const routes = {
   legal: "/legal",
 
   // Content routes
+  about: "/about",
   faq: "/faq",
   changelog: "/changelog",
   contact: "/contact",


### PR DESCRIPTION
## Summary

Template-level SEO improvements for bones upstream. All downstream sites inherit these fixes.

- Added explicit `<meta charset="utf-8">` to root layout (was missing from rendered HTML)
- Created `/about` page scaffold using `siteConfig` for downstream customization
- Rewrote `/privacy-policy` from placeholder content to proper template
- Added unique `metadata` exports to all legal pages (privacy, terms, EULA)
- Expanded `routeMetadata` config with entries for about, privacy, terms, and changelog
- Added `/about` route to routes config
- Removed incorrect `next/head` import (Pages Router pattern in App Router codebase)

## Context

Part of [LAC-251] — cross-property SEO fixes. Board directed template-level fixes to `bones` upstream so all downstream sites (shipkit, lash-www, TOH-new, etc.) inherit automatically.

## Test plan

- [x] `pnpm build` passes with no errors
- [ ] `/about` renders with correct title and description meta tags
- [ ] `/privacy-policy` renders updated content with metadata
- [ ] `<meta charset="utf-8">` appears in page source HTML
- [ ] Legal pages (terms, eula) have unique `<title>` tags instead of default