### PR TITLE
chore: community health files + CodeQL workflow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,54 +1,67 @@
-# Contributing to Shipkit
+# Contributing to Shipkit Bones
 
-We love your input! We want to make contributing to Shipkit as easy and transparent as possible, whether it's:
+Thanks for your interest. **Shipkit Bones** is the free, AGPL-licensed boilerplate that the rest of the Shipkit ecosystem builds on. It's a Next.js 15 (App Router + TypeScript) starter with Tailwind, Shadcn/UI, Drizzle ORM, Payload CMS, and integrations across auth, payments, email, and AI providers.
 
-- Reporting a bug
-- Discussing the current state of the code
-- Submitting a fix
-- Proposing new features
-- Becoming a maintainer
+## Quick start
 
-## We Develop with GitHub
+Prerequisites: **Bun**, **PostgreSQL** (or a hosted Postgres URL), Node 20+.
 
-We use GitHub to host code, to track issues and feature requests, as well as accept pull requests.
+```bash
+git clone https://github.com/shipkit-io/bones.git
+cd bones
+bun install
+cp .env.example .env       # only DATABASE_URL is required to boot
 
-## We Use [GitHub Flow](https://guides.github.com/introduction/flow/index.html)
+bun dev                    # Next dev server with Turbo
+bun run db:migrate         # apply migrations once .env is set
+```
 
-Pull requests are the best way to propose changes to the codebase. We actively welcome your pull requests:
+See [`CLAUDE.md`](../CLAUDE.md) for the architecture deep-dive: route groups, services / actions split, feature-flag system, Payload integration.
 
-1. Fork the repo and create your branch from `main`.
-2. If you've added code that should be tested, add tests.
-3. If you've changed APIs, update the documentation.
-4. Ensure the test suite passes.
-5. Make sure your code lints.
-6. Issue that pull request!
+## Reporting bugs
 
-## Any contributions you make will be under the MIT Software License
+Open an issue using the **Bug Report** template. Include the URL or page, exact reproduction steps, what you expected, what you saw, and (if relevant) which feature flags were enabled. Browser/OS only when the bug is visual or device-specific.
 
-In short, when you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project. Feel free to contact the maintainers if that's a concern.
+## Proposing changes
 
-## Report bugs using GitHub's [issue tracker](https://github.com/shipkit/shipkit/issues)
+For non-trivial work — new routes, schema changes, auth/permission changes, new integrations — open an issue first to align on the approach. Small fixes (typos, dead links, single-file bugs) can go straight to a PR.
 
-We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/shipkit/shipkit/issues/new/choose); it's that easy!
+Because Bones is the upstream for `shipkit` and several downstream sites, changes here ripple. Be conservative about renames and breaking refactors; flag them in the PR description.
 
-## Write bug reports with detail, background, and sample code
+## Pull requests
 
-**Great Bug Reports** tend to have:
+1. Branch from `main`. Use a descriptive name (`fix/auth-redirect`, `feat/builder-page`).
+2. One logical change per PR. Don't bundle refactors with feature work.
+3. Follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `perf:`, `test:`).
+4. Fill in the PR template — especially the test plan.
 
-- A quick summary and/or background
-- Steps to reproduce
-  - Be specific!
-  - Give sample code if you can.
-- What you expected would happen
-- What actually happens
-- Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
+## Code style
 
-## Use a Consistent Coding Style
+- **Server Components first.** Reach for `'use client'` only when you need browser-only APIs or interactivity.
+- **Server Actions for mutations**, Server Components for data fetching. Never use server actions to fetch.
+- **Services layer.** Business logic lives in `src/server/services/`; mutation actions in `src/server/actions/` call services. **Server Components call services directly for data fetching.** **Client Components call actions for mutations** — never reach into services from the client.
+- **Drizzle + Postgres.** Schema in `src/server/db/schema.ts`. After edits: `bun run db:generate` → `bun run db:migrate`. Prefer timestamps over booleans (`activeAt`, not `isActive`).
+- **TypeScript.** Strict; no `any` without an explanatory comment. Interfaces over types; no enums (use objects/maps).
+- **Naming.** kebab-case files, PascalCase components, camelCase variables. Named exports only — no default exports.
+- **File size.** Keep files under 500 lines.
+- **Feature flags.** Toggle features via `NEXT_PUBLIC_FEATURE_*_ENABLED` env vars. Features must degrade cleanly when disabled.
 
-- Use TypeScript for all code
-- Run `bun run lint:fix` to ensure consistent formatting
-- Follow the existing code style patterns
+Run before pushing:
+
+```bash
+bun run lint:fix       # Biome + ESLint + Prettier auto-fix
+bun run typecheck      # tsc --noEmit
+bun test               # Vitest
+```
+
+## Downstream impact
+
+Bones is the upstream for [`shipkit`](https://github.com/lacymorrow/shipkit) and several deployed sites. Downstream repos track their bones version via the `shipkit.bones` key in `package.json` and sync via `scripts/git-sync-upstream.ts`. When making changes here, consider whether downstream consumers will need migration notes — call those out in the PR description.
+
+## Security
+
+Please **do not open public issues for security vulnerabilities**. See [SECURITY.md](SECURITY.md) for private disclosure.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under its MIT License.
+Bones is licensed under [AGPL-3.0-only](../LICENSE). By contributing, you agree that your contributions will be licensed under the same terms. AGPL is copyleft: any network-deployed derivative must also be open-sourced under AGPL. If that's a deal-breaker for your use case, the premium [Shipkit](https://shipkit.io) framework is available under a commercial license.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+<!--
+Thanks for the contribution! A few things that make review faster:
+- Keep the PR focused on one logical change
+- Use Conventional Commits in the title (feat: / fix: / chore: / docs: / refactor: / perf: / test:)
+- Fill in the test plan — that's the part reviewers actually depend on
+- If your change ripples to downstream Shipkit consumers, flag it in Reviewer notes
+-->
+
+## Summary
+
+<!-- One or two sentences: what changes and why. -->
+
+## Changes
+
+<!-- Bullet list of notable changes. Skip if Summary already covers it. -->
+-
+
+## Test plan
+
+<!-- How a reviewer can verify this. Be specific. -->
+- [ ] `bun run typecheck` passes
+- [ ] `bun run lint` passes
+- [ ] `bun test` passes (if relevant)
+- [ ] Manually verified the affected route / flow at `/...`
+- [ ] DB schema changes ran cleanly via `bun run db:migrate` (delete if N/A)
+
+## Screenshots / recordings
+
+<!-- For UI changes. Before/after when possible. Delete if not applicable. -->
+
+## Related issues
+
+<!-- Closes #123 / Refs #456 -->
+
+## Downstream impact
+
+<!-- Does this break the upstream API consumed by `shipkit` or downstream sites?
+     If yes, list migration notes. Delete this section if N/A. -->
+
+## Reviewer notes
+
+<!-- Anything reviewers should focus on, risks worth flagging, follow-ups intentionally deferred. -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please **do not** open public GitHub issues for security vulnerabilities.
+
+Use one of these private channels instead:
+
+1. **GitHub Security Advisory** (preferred) — [open a private advisory](https://github.com/shipkit-io/bones/security/advisories/new).
+2. **Email** — `security@shipkit.io`.
+
+You should expect:
+
+- An acknowledgement within **3 business days**.
+- An initial assessment (confirmed / not-reproducible / out-of-scope) within **10 business days**.
+- Coordinated disclosure with credit to the reporter once a fix ships.
+
+## In scope
+
+Bones is a self-deployable Next.js boilerplate. Issues that affect any deployment derived from this repo are in scope:
+
+- Authentication and session handling (NextAuth, Better Auth, Payload credentials)
+- Authorization / role escalation (admin endpoints, ownership boundaries)
+- SSRF / open redirects / injection in any user-facing input
+- Stored or reflected XSS, CSRF on state-changing endpoints
+- Payment / billing flows (Lemon Squeezy, Stripe, Polar) that bypass authorization or leak data
+- Secret or PII exposure in API responses, logs, or error pages
+- Misconfigured defaults that would compromise a fresh deployment (e.g., dev secrets accepted in production, permissive CORS, missing rate limits on auth)
+
+## Out of scope
+
+- Vulnerabilities that require an already-compromised admin account
+- Best-practice findings without a working PoC (missing headers, outdated lib versions with no exploit) — file as normal issues
+- Volumetric denial of service
+- Issues in third-party services (Auth.js, Payload, Drizzle, etc.) — report those upstream
+
+## Downstream deployments
+
+Bones is the upstream for [`shipkit`](https://github.com/lacymorrow/shipkit) and a number of derived sites. If you find an issue in a deployed downstream site (e.g., `shipkit.io`), please report it to that site's security contact instead — we'll backport the fix to bones if it's upstream-relevant.
+
+## Supported versions
+
+Only `main` is supported. Tagged releases (`0.x`) are reference points for downstream syncs, not maintenance branches. If you're running an older `main`, please update first.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 7 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint:biome": "biome lint .",
     "lint:eslint": "next lint",
     "lint:prettier": "prettier --check \"**/*.{ts,tsx,md,mdx,json}\"",
-    "lint:fix": "npm run lint:fix:biome && npm run lint:fix:eslint && npm run format",
+    "lint:fix": "npm run lint:fix:biome && npm run lint:fix:eslint && npm run lint:fix:prettier",
     "lint:fix:biome": "biome check --write .",
     "lint:fix:eslint": "next lint --fix",
     "lint:fix:prettier": "prettier --write \"**/*.{ts,tsx,md,mdx,json}\"",


### PR DESCRIPTION
## Summary

Polishes the bones repo surface — no runtime code touched. Same playbook applied to juno and paperclip-hub.

## Changes

- **CONTRIBUTING.md** — rewrote. Previous file was stock shipkit boilerplate that claimed MIT (Bones is **AGPL-3.0**) and pointed at `github.com/shipkit/shipkit/issues` (wrong tracker, wrong project). Now reflects the actual stack, dev commands, services/actions split, AGPL implications, and the downstream-impact dance with `shipkit` and derived sites.
- **SECURITY.md** — private disclosure path via the [GHSA advisory form](https://github.com/shipkit-io/bones/security/advisories/new) + `security@shipkit.io`. Scope explicitly covers auth, billing flows, and "misconfigured defaults that would compromise a fresh deployment" — important for a boilerplate.
- **PULL_REQUEST_TEMPLATE.md** — summary / changes / test plan / screenshots / **downstream impact** / reviewer notes. The downstream-impact section is bones-specific (changes ripple to shipkit and derived sites).
- **`.github/workflows/codeql.yml`** — javascript-typescript matrix, `security-and-quality` queries, push/PR on main + weekly Monday cron. Bones has half a dozen AI bot workflows but no actual static analysis was running.
- **package.json** — fix `lint:fix` chain. Was running `npm run format` which doesn't exist — now chains to `lint:fix:prettier`.

## Test plan

- [x] `git status` clean apart from the intended files (left untouched: in-progress `.clinerules`, `.cursor/rules/...`, `public/llms*`, etc.)
- [ ] CodeQL workflow runs successfully on this PR
- [ ] `bun run lint:fix` now completes without "command not found" on the format step

## Reviewer notes

Discussions intentionally **not** enabled this round. Description and homepage (`https://bones.sh`) are already correct upstream; topics are already populated. The only repo-metadata change still worth doing manually is uploading the social-preview PNG via Settings → General — coming in a follow-up PR.