### PR TITLE
fix(auth): wrap OAuthButtons in Suspense to prevent stuck loading state

### DIFF
--- a/src/app/(app)/(authentication)/_components/login-form.tsx
+++ b/src/app/(app)/(authentication)/_components/login-form.tsx
@@ -1,6 +1,7 @@
-import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { type ComponentPropsWithoutRef, type ReactNode, Suspense } from "react";
 
 import { OAuthButtons } from "@/app/(app)/(authentication)/_components/oauth-buttons";
+import { SuspenseFallback } from "@/components/primitives/suspense-fallback";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { routes } from "@/config/routes";
 import { cn } from "@/lib/utils";
@@ -40,7 +41,9 @@ export function AuthForm({
 				</CardHeader>
 				<CardContent>
 					<div className="grid gap-6">
-						<OAuthButtons />
+						<Suspense fallback={<SuspenseFallback />}>
+							<OAuthButtons />
+						</Suspense>
 						{/* Only show email sign-in if credentials provider is enabled */}
 						{authProvidersArray.includes("credentials") && (
 							<>


### PR DESCRIPTION
## Summary

- `OAuthButtons` uses `useSearchParams()` which causes the component to suspend during SSR/hydration
- Without a local `<Suspense>` boundary, the suspension bubbles up to the route-level `loading.tsx`, showing "Loader..." indefinitely
- Wraps `<OAuthButtons>` in `<Suspense fallback={<SuspenseFallback />}>` to scope the suspension

This fix was already applied in shipkit (premium) and shipkit-www. Propagating upstream to bones so all downstream forks get it.

Ref: LAC-1946, shipkit-www PR #47

## Test plan

- [ ] Visit `/sign-in` — confirm OAuth buttons render (not stuck on loader)
- [ ] Visit `/sign-up` — confirm same fix applies
- [ ] Verify no hydration warnings in console