### PR TITLE
chore(security): add gitleaks pre-commit + CI secret scan (LAC-2555)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+# Secret scanner — LAC-2555
+#
+# Blocks commits that introduce plaintext credentials.
+# Requires `gitleaks` locally; if not installed we print a warning and
+# fall through — CI still runs the same scan on the PR, so this is
+# defense-in-depth, not the only gate.
+#
+# Install:
+#   macOS   → brew install gitleaks
+#   linux   → https://github.com/gitleaks/gitleaks/releases
+
+if command -v gitleaks >/dev/null 2>&1; then
+  if ! gitleaks protect --staged --redact --no-banner; then
+    echo ""
+    echo "gitleaks found a potential secret in staged changes."
+    echo "If real: rotate the credential first, then remove it from the diff."
+    echo "If a false positive: extend .gitleaks.toml allowlist or add an inline"
+    echo "'gitleaks:allow' comment. Do not disable the hook."
+    exit 1
+  fi
+else
+  echo "gitleaks not installed — skipping local secret scan (CI still runs)."
+  echo "  install: brew install gitleaks"
+fi

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,30 @@
+# Secret scan — LAC-2555
+#
+# Fails the PR/push if plaintext credentials appear in the diff.
+# Config lives in .gitleaks.toml at the repo root.
+#
+# Local defense-in-depth: .husky/pre-commit runs the same tool on staged
+# changes when the gitleaks binary is installed.
+
+name: gitleaks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,10 +1,15 @@
-# Secret scan — LAC-2555
+# Secret scan — LAC-2555 (fix: LAC-3287)
 #
-# Fails the PR/push if plaintext credentials appear in the diff.
+# Scans the PR/push diff with the gitleaks CLI. We install the binary
+# directly instead of using gitleaks/gitleaks-action@v2 because that
+# action requires a paid license for GitHub Organizations
+# (shipkit-io is an org — v2 hard-errors with "missing gitleaks
+# license" and fails the check). The CLI has no such restriction.
+#
 # Config lives in .gitleaks.toml at the repo root.
 #
-# Local defense-in-depth: .husky/pre-commit runs the same tool on staged
-# changes when the gitleaks binary is installed.
+# Local defense-in-depth: .githooks/pre-commit runs the same tool on
+# staged changes when the gitleaks binary is installed.
 
 name: gitleaks
 
@@ -17,14 +22,46 @@ permissions:
   contents: read
 
 jobs:
-  gitleaks:
+  scan-diff:
     name: gitleaks
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
         with:
+          # Need history so gitleaks can walk the PR range or push delta.
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          VERSION="8.21.2"
+          curl -sSfL -o /tmp/gitleaks.tgz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz"
+          tar -xzf /tmp/gitleaks.tgz -C /tmp gitleaks
+          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+      - name: Determine scan range
+        id: range
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+            echo "log_opts=--no-merges ${BASE}..${HEAD}" >> "$GITHUB_OUTPUT"
+          else
+            BEFORE="${{ github.event.before }}"
+            if [[ -z "$BEFORE" || "$BEFORE" == "0000000000000000000000000000000000000000" ]]; then
+              echo "log_opts=-1 HEAD" >> "$GITHUB_OUTPUT"
+            else
+              echo "log_opts=--no-merges ${BEFORE}..${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+      - name: Scan diff
+        run: |
+          set -euo pipefail
+          gitleaks git \
+            --config .gitleaks.toml \
+            --redact \
+            --verbose \
+            --exit-code 1 \
+            --log-opts="${{ steps.range.outputs.log_opts }}"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,23 @@
+# gitleaks config — LAC-2555
+#
+# Extends the built-in rule set. Allowlist covers files that legitimately
+# contain placeholder credentials (example env files, docs, changelogs).
+# When you add a new placeholder file that trips gitleaks, extend the
+# `paths` list here rather than removing the scan.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Placeholder-credential files and generated docs"
+paths = [
+  '''(^|/)\.env\.example(\..+)?$''',
+  '''(^|/)\.env\.example\.local$''',
+  '''(^|/)\.env\.test$''',
+  '''(^|/)\.env\.example\.production$''',
+  '''(^|/)README\.md$''',
+  '''(^|/)CHANGELOG\.md$''',
+  '''(^|/)LICENSE$''',
+  '''(^|/)docs/''',
+  '''(^|/)public/llms(-full)?\.txt$''',
+]

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "test:coverage": "vitest run --coverage",
     "test:browser": "vitest --config=vitest.config.browser.ts",
     "test:node": "vitest --config=vitest.config.node.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "postinstall": "git config core.hooksPath .githooks 2>/dev/null || true"
   },
   "dependencies": {
     "@auth/drizzle-adapter": "1.11.1",


### PR DESCRIPTION
## Summary

Adds a two-layer secret scanner per LAC-2555 (Paperclip): CI-side gate + local pre-commit hook. Follows LAC-2548, where a plaintext OpenAI key made it into the repo.

- **CI gate**: `.github/workflows/gitleaks.yml` runs [gitleaks-action](https://github.com/gitleaks/gitleaks-action) on every PR and every push to `main`. Fails the check if a plaintext credential appears in the diff.
- **Local hook**: `.githooks/pre-commit` runs `gitleaks protect --staged` when the binary is installed. Graceful skip + warning if not — CI still catches it either way.
- **Auto-wiring**: `postinstall` sets `git config core.hooksPath .githooks` so the hook activates on the next install without adding a new devDependency.
- **Config**: `.gitleaks.toml` extends the default rule set and allowlists placeholder-credential files (`.env.example*`, `docs/`, LLM crawl fixtures) so we don't false-positive.

Scope kept tight per Rule 28 — no refactors, no other changes.

## Test plan

- [ ] CI job "gitleaks" appears on this PR and passes (nothing sensitive in the diff).
- [ ] After merge, `git config core.hooksPath` reads `.githooks` after `pnpm install` / `bun install`.
- [ ] Manual leak test: `echo "AWS_SECRET_ACCESS_KEY=AKIA...redacted" > /tmp/leak.txt && git add /tmp/leak.txt && git commit -m test` should fail locally (if gitleaks installed) or on CI.

Refs: LAC-2555, LAC-2548, LAC-2554 (credential rotation, tracked separately).