### PR TITLE
fix(seo): serve OG image from bones.sh; document canonical repo (LAC-2792)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Deployment: this repo is canonical for bones.sh
+
+**Production for [bones.sh](https://bones.sh) deploys from THIS repo** (`shipkit-io/bones`, branch `main`) via the Vercel project `bones` (`prj_GoLdhv6ei8JKqK9jydtLv5wgLzzx`). Changes intended for bones.sh production must land here.
+
+Do NOT use `lacymorrow/bones-www` for bones.sh work — it is archived and deploys nowhere (its Vercel project was deleted; see LAC-2792). Fixes merged there between Feb and Jun 2026 never reached production.
+
 ## Essential Development Commands
 
 ### Development Server

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 ## Deploy on Vercel
 
+> **Note for maintainers:** [bones.sh](https://bones.sh) production deploys from **this repo** (`shipkit-io/bones`, branch `main`) via the Vercel project `bones`. The old `lacymorrow/bones-www` repo is archived and no longer deploys anywhere — changes for bones.sh belong here.
+
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.

--- a/src/config/site-config.ts
+++ b/src/config/site-config.ts
@@ -126,7 +126,7 @@ export const siteConfig: SiteConfig = {
 	name: "Bones",
 	title: "Launch your app today",
 	url: "https://bones.sh",
-	ogImage: "https://shipkit.io/og",
+	ogImage: "https://bones.sh/og",
 	description:
 		"Launch your app at light speed. Fast, flexible, and feature-packed for the modern web.",
 

--- a/tests/unit/seo-og-image.test.ts
+++ b/tests/unit/seo-og-image.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { siteConfig } from "@/config/site-config";
+
+/**
+ * Regression test for LAC-2792: prod served og:image from shipkit.io
+ * (ShipKit branding) because the bones-www fix for this never reached the
+ * canonical repo. Social shares of bones.sh must use Bones' own OG image.
+ *
+ * Invariant: the OG image lives on the site's own domain, which has a
+ * working /og route.
+ */
+
+describe("og image", () => {
+	it("serves the OG image from the site's own domain", () => {
+		expect(new URL(siteConfig.ogImage).origin).toBe(new URL(siteConfig.url).origin);
+	});
+});


### PR DESCRIPTION
## Paperclip issue
LAC-2792 — bones.sh repo/deploy mapping: bones-www changes never reach prod.

## Summary
- **Fix:** `siteConfig.ogImage` pointed at `https://shipkit.io/og`, so social shares of bones.sh showed ShipKit's OG image. bones-www fixed this in Mar 2026 (ed542128) but that repo stopped deploying to bones.sh, so the fix never shipped. Now points at bones.sh's own working `/og` route.
- **Regression test:** `tests/unit/seo-og-image.test.ts` asserts the OG image origin matches the site origin (fails on the bug, passes after).
- **Docs:** CLAUDE.md + README now state that **this repo is canonical for bones.sh production** (Vercel project `bones`, branch `main`) and that `lacymorrow/bones-www` is dead for bones.sh.

## Testing
- `bunx vitest run tests/unit/` → 2 files, 4 tests passed (new test verified red before the fix).
- Verified `https://bones.sh/og` returns `200 image/png`.

## Acceptance criteria (LAC-2792)
- Canonical repo decided + documented in this repo (bones-www side handled in a separate PR there before archiving).