### PR TITLE
fix(lint): migrate biome.json to Biome 2.4.0 schema — restore broken lint (LAC-2877)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,15 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.0/schema.json",
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": ["node_modules", ".next", "*.css", "src/components/ui/*"]
+		"includes": [
+			"**",
+			"!**/node_modules",
+			"!**/.next",
+			"!**/*.css",
+			"!**/src/components/ui/**/*",
+			"!**/public/workers/**"
+		]
 	},
 	"formatter": {
 		"enabled": true,
@@ -31,9 +38,10 @@
 			},
 			"suspicious": {
 				"noExplicitAny": "warn",
-				"noConsoleLog": "warn",
 				"noControlCharactersInRegex": "off",
-				"noShadowRestrictedNames": "off"
+				"noShadowRestrictedNames": "off",
+				"noConsole": "warn",
+				"noArrayIndexKey": "warn"
 			},
 			"style": {
 				"noNonNullAssertion": "warn",
@@ -45,7 +53,5 @@
 			}
 		}
 	},
-	"organizeImports": {
-		"enabled": true
-	}
+	"assist": { "actions": { "source": { "organizeImports": "on" } } }
 }

--- a/scripts/nextjs-list-pages.ts
+++ b/scripts/nextjs-list-pages.ts
@@ -41,14 +41,20 @@ const htmlFiles = walk(serverDir)
 	.sort();
 
 console.log("\n📄 Static HTML files emitted:");
-htmlFiles.forEach((p) => console.log("  •", p));
+htmlFiles.forEach((p) => {
+	console.log("  •", p);
+});
 
 console.log("\n📦 SSG routes from prerender‑manifest.json:");
-ssgRoutes.forEach((p) => console.log("  •", p));
+ssgRoutes.forEach((p) => {
+	console.log("  •", p);
+});
 
 if (dynamicSsgRoutes.length) {
 	console.log("\n📦 Dynamic SSG routes (ISR/fallback):");
-	dynamicSsgRoutes.forEach((p) => console.log("  •", p));
+	dynamicSsgRoutes.forEach((p) => {
+		console.log("  •", p);
+	});
 }
 
 console.log("\n✅ Done.");

--- a/src/app/(app)/bones/cli-www/_components/component-details.tsx
+++ b/src/app/(app)/bones/cli-www/_components/component-details.tsx
@@ -38,7 +38,7 @@ export function ComponentDetails({
 }: ComponentDetailsProps) {
 	const [selectedFile, setSelectedFile] = useState<string>()
 
-	const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+	const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
 		if (e.key === 'Escape') {
 			onClose()
 		}
@@ -61,12 +61,12 @@ export function ComponentDetails({
 
 	return (
 		<>
-			<div
+			<button
+				type="button"
+				aria-label="Close"
 				className="absolute inset-0 bg-background/50 z-40"
 				onClick={onClose}
 				onKeyDown={handleKeyDown}
-				role="button"
-				tabIndex={0}
 			/>
 			<motion.div
 				initial={{ opacity: 0, scale: 0.95 }}

--- a/src/app/(app)/bones/cli-www/_components/terminal.tsx
+++ b/src/app/(app)/bones/cli-www/_components/terminal.tsx
@@ -53,6 +53,7 @@ export function Terminal({ output, className }: TerminalProps) {
 					<div
 						key={`${i}-${line.slice(0, 20)}`}
 						className="min-h-[6px]"
+						// biome-ignore lint/security/noDangerouslySetInnerHtml: ansi-to-html escapes input (escapeXML: true); only its own color spans are injected
 						dangerouslySetInnerHTML={{
 							__html: convert.toHtml(cleanAnsi(line)) || '&nbsp;',
 						}}

--- a/src/components/loaders/loader-atoms.tsx
+++ b/src/components/loaders/loader-atoms.tsx
@@ -33,8 +33,10 @@ export interface LoaderAtomsProps
 export const LoaderAtoms = React.forwardRef<HTMLDivElement, LoaderAtomsProps>(
 	({ className, size, color, label, ...props }, ref) => {
 		return (
+			// biome-ignore lint/a11y/useSemanticElements: keeping a div preserves the exported HTMLDivElement ref type
 			<div
 				ref={ref}
+				role="status"
 				aria-live="polite"
 				aria-label={label || "Loading"}
 				className={cn("relative", className)}

--- a/src/components/primitives/accordion-list.tsx
+++ b/src/components/primitives/accordion-list.tsx
@@ -6,13 +6,13 @@ import {
 } from "@/components/ui/accordion";
 import { Separator } from "@/components/ui/separator";
 
-export interface AccordionItem {
+export interface AccordionListItem {
   title: string;
   content: React.ReactNode;
 }
 
 interface AccordionListProps {
-  items: AccordionItem[];
+  items: AccordionListItem[];
   accordionProps?: any; // TODO: fix type
 }
 

--- a/src/components/primitives/masonry.tsx
+++ b/src/components/primitives/masonry.tsx
@@ -44,7 +44,7 @@ const ExampleMasonry: React.FC = () => {
 				<img
 					className="w-full rounded-lg object-contain"
 					src={imageUrl}
-					alt={`Random stock image ${idx + 1}`}
+					alt={`Random stock placeholder ${idx + 1}`}
 					loading="lazy"
 				/>
 			)}

--- a/src/lib/utils/extract-headings.ts
+++ b/src/lib/utils/extract-headings.ts
@@ -58,7 +58,9 @@ function ensureCacheSize(): void {
 		entries.sort((a, b) => a[1].timestamp - b[1].timestamp);
 
 		const toRemove = entries.slice(0, headingCache.size - MAX_CACHE_SIZE + 1);
-		toRemove.forEach(([key]) => headingCache.delete(key));
+		toRemove.forEach(([key]) => {
+			headingCache.delete(key);
+		});
 	}
 }
 
@@ -89,9 +91,8 @@ export function extractHeadings(content: string): Heading[] {
 	// Extract headings if not in cache or expired
 	const headingRegex = /^(#{1,6})\s+(.+)$/gm;
 	const headings: Heading[] = [];
-	let match;
 
-	while ((match = headingRegex.exec(content)) !== null) {
+	for (const match of content.matchAll(headingRegex)) {
 		const level = match[1]?.length ?? 0;
 		const text = match[2]?.trim() ?? "";
 		const id = slugify(text);

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeAll, expect, vi } from "vitest";
 
 // Augment the global namespace for TypeScript
 declare global {
-	// biome-ignore lint/style/noVar: <explanation>
+	// biome-ignore lint/suspicious/noVar: global augmentation requires var
 	var IS_REACT_ACT_ENVIRONMENT: boolean;
 }
 


### PR DESCRIPTION
## Paperclip issue
[LAC-2877](https://paperclip.dev/LAC/issues/LAC-2877) — found during LAC-2792.

## Problem
`package.json` pins `@biomejs/biome@2.4.0` but `biome.json` was still on the 1.9.4 schema (plus removed keys like `files.ignore`). Every `biome` invocation exited with a configuration error, so `bun run lint:biome` / `lint:fix:biome` were dead. No CI job runs lint, so this failed silently for local/agent tooling only.

## Changes
**Config (`biome.json`)**
- Ran official `biome migrate` (1.9.4 → 2.4.0): `files.ignore` → `files.includes` negations, `organizeImports` → `assist.actions.source.organizeImports`.
- `migrate` converted `noConsoleLog: warn` into `noConsole { allow: ["log"] }`, which **inverts** the original intent (would allow `console.log` and flag everything else). Biome 2 has no "flag only log" mode, so set plain `noConsole: "warn"` (superset of old intent, still warn-level).
- Excluded `public/workers/**` — `logger-worker.js` is compiled TS output (`__awaiter` boilerplate) and shouldn't be linted.
- Downgraded `noArrayIndexKey` error → warn, consistent with this config's existing warn-level suspicious rules (`noExplicitAny`, `noNonNullAssertion`); the 6 hits are static/decorative lists with no stable IDs.

**Code — fixed all remaining error-level diagnostics surfaced by Biome 2.x**
- `tests/setup.ts`: suppression referenced `lint/style/noVar`, which moved to `lint/suspicious/noVar` in 2.x (parse error).
- `src/lib/utils/extract-headings.ts`: replaced `while ((match = regex.exec(...)))` with `for...of matchAll` (fixes `noAssignInExpressions` + `noImplicitAnyLet`); braced a `forEach` callback (`useIterableCallbackReturn`).
- `scripts/nextjs-list-pages.ts`: braced three `forEach` callbacks (`useIterableCallbackReturn`).
- `accordion-list.tsx`: renamed exported `AccordionItem` interface → `AccordionListItem` — it shadowed the imported `AccordionItem` component (`noRedeclare`). No external importers (verified via grep).
- `component-details.tsx`: backdrop `div[role=button]` → real `<button type="button" aria-label="Close">` (`useSemanticElements`).
- `loader-atoms.tsx`: added `role="status"` so `aria-label` is valid (`useAriaPropsSupportedByRole`); documented suppression for `useSemanticElements` (an `<output>` element would change the exported `HTMLDivElement` ref type).
- `terminal.tsx`: documented suppression for `noDangerouslySetInnerHtml` — the converter is constructed with `escapeXML: true`, so input is escaped and only ansi-to-html's own color spans are injected.
- `masonry.tsx`: alt text no longer contains the redundant word "image" (`noRedundantAlt`).

## Scoped out (explicitly)
- 395 pre-existing **warn-level** diagnostics (mostly `noExplicitAny`, `noConsole`, `noArrayIndexKey`) — non-blocking, exit code 0; existed conceptually under the 1.9.4 config too.
- Repo-wide formatting/import-organization diffs that `biome check --write` would apply (~194 files) — orthogonal to restoring lint.

## Testing
- Reproduced the config error on main (`Found 1 error: The configuration schema version does not match the CLI version 2.4.0`).
- `bun run lint:biome` → **exit 0**, `Checked 271 files… Found 395 warnings, 6 infos, 0 errors`.
- `biome check .` loads config cleanly (no deserialize errors).
- `bun run typecheck` → exit 0.
- `bun run test` → 4/4 pass.