### PR TITLE
chore(security): gitignore .specstory/ + audit public history (LAC-3244)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ env/
 *.env*
 !.env.example
 
+# Secret-scan hygiene (LAC-3244)
+# .specstory persists chat transcripts that have historically captured live tokens.
+.specstory/
+
 # TypeScript
 *.tsbuildinfo
 next-env.d.ts


### PR DESCRIPTION
## Summary
Adds `.specstory/` to `.gitignore` in bones (public repo). Closes item split from [LAC-3163] secret-scan hygiene.

`.specstory/` persists AI chat transcripts that have historically captured live tokens (16 Sourcegraph + Stripe sk_test found in **shipkit** commit 8d4b036d). This prevents future transcripts from being committed here.

## Public-history audit (escalation-critical part of LAC-3244)
bones is **public**, so its history was audited for exposed tokens:
- Files ever under `.specstory/` in history: `.what-is-this.md` (boilerplate) + one transcript `2025-06-30…google-search-console.md`.
- `gitleaks git --all -- .specstory` → **0 leaks**.
- Manual pattern scan (sk-ant/sk-proj/ghp_/sk_live/sk_test/AKIA/AIza/sgp_/JWT/PEM/client_secret/generic-key) → **0 matches**.

**Conclusion: no live public exposure in bones.** No history rewrite needed for bones.

## Scope
Single-line `.gitignore` change only. Unrelated untracked files in the working tree (`.clinerules`, `.cursor/rules/*`, `.windsurfrules`, copilot-instructions) were intentionally left out of this PR.

Refs LAC-3244, parent LAC-3163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)