### PR TITLE
chore(deps): add Dependabot dependency-update routine (LAC-3320)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+# Dependabot keeps dependencies current on a routine schedule so upgrades land
+# as small, reviewable PRs instead of one big painful sweep (see LAC-3320).
+#
+# How it works: Dependabot opens grouped PRs every Monday. Minor/patch bumps are
+# batched into a single PR per ecosystem to avoid noise; major bumps open on their
+# own so they get individual review.
+#
+# pnpm note: the npm ecosystem drives pnpm projects — Dependabot reads pnpm-lock.yaml.
+version: 2
+updates:
+  # App JavaScript dependencies (root package.json)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      # One PR for all safe (minor + patch) production dependency bumps
+      production-minor-patch:
+        applies-to: version-updates
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      # One PR for all dev dependency bumps
+      development:
+        applies-to: version-updates
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    # Major bumps of framework-critical packages get opened individually (not
+    # grouped), but never auto-batched with the rest — they always need a human.
+
+  # GitHub Actions used by the workflows in .github/workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/docs/development/dependency-updates.mdx
+++ b/docs/development/dependency-updates.mdx
@@ -1,0 +1,61 @@
+---
+title: "Dependency Updates"
+description: "How Bones keeps its dependencies current, and how to run an update by hand"
+---
+
+# Dependency Updates
+
+Bones keeps dependencies fresh on a routine schedule so upgrades land as small,
+reviewable pull requests instead of one big painful sweep. Two layers cover this:
+automated Dependabot PRs (the default) and a manual escape hatch for one-off bumps.
+
+## Automated: Dependabot
+
+Dependabot is configured in [`.github/dependabot.yml`](https://github.com/shipkit-io/bones/blob/main/.github/dependabot.yml).
+Every Monday it opens grouped pull requests:
+
+- **Production minor/patch** — one PR batching all safe production dependency bumps.
+- **Dev dependencies** — one PR batching all dev dependency bumps.
+- **Major bumps** — opened individually so each gets a deliberate human review.
+- **GitHub Actions** — one PR for workflow action updates.
+
+Bones uses pnpm; Dependabot reads `pnpm-lock.yaml` via the `npm` ecosystem.
+
+### Reviewing a Dependabot PR
+
+1. Let CI run — a green build is the baseline gate.
+2. Skim the linked changelog/release notes for each bumped package, especially anything
+   touching auth, payments, or the consent/privacy layer (`@c15t/*`). Minor releases are
+   usually safe; read the notes anyway.
+3. For grouped minor/patch PRs with green CI, merge. For major bumps, treat it like a
+   feature change: read the migration guide, test the affected surface, then merge.
+
+## Manual: on-demand updates
+
+When you need to bump something before the weekly cadence (a security fix, a specific
+release you're waiting on), do it by hand:
+
+```bash
+pnpm run deps:check     # ncu — list what is outdated
+pnpm run deps:update    # ncu -u — rewrite package.json to latest ranges
+pnpm install            # refresh pnpm-lock.yaml
+pnpm run typecheck      # confirm nothing broke
+pnpm run lint           # confirm nothing broke
+```
+
+To bump a single package instead of everything:
+
+```bash
+pnpm update <package>           # within the current semver range
+# or edit the version in package.json, then:
+pnpm install
+```
+
+Always run `typecheck` and `lint` after any update, and open a PR — never push
+dependency bumps straight to `main`.
+
+## Where this applies
+
+This process ships in `bones` (the free starter) and flows to every downstream
+Shipkit site via the upstream sync. Each downstream repo inherits the same
+`.github/dependabot.yml`, so the whole family stays current without per-repo setup.


### PR DESCRIPTION
## Summary

Backfills the Dependabot config from shipkit ([LAC-3319 / PR #278](https://github.com/lacymorrow/shipkit/pull/278)) into bones so every downstream Shipkit site inherits the weekly dependency-update cadence via upstream sync.

- `.github/dependabot.yml` — weekly Monday PRs, grouped minor/patch for prod and dev, individual major bumps, plus a `github-actions` ecosystem entry.
- `docs/development/dependency-updates.mdx` — documents the automated cadence and the manual `pnpm`-based escape hatch.

Adapted from the shipkit version for bones: dropped the `/cli` subpath (bones has no CLI package), swapped the Bun lockfile note for `pnpm-lock.yaml`, and rewrote the manual-update commands as `pnpm run …`.

Paperclip: LAC-3320
Parent: LAC-3319

## Test plan

- [ ] Merge and confirm the next Monday Dependabot run opens grouped PRs against bones.
- [ ] Downstream `sync-upstream` runs pull the config into shipkit family repos on their next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)