### PR TITLE
fix(seo): derive og:url from canonical, single H1 per page, normalize meta descriptions (LAC-3521)

### DIFF
--- a/src/app/(app)/(authentication)/layout.tsx
+++ b/src/app/(app)/(authentication)/layout.tsx
@@ -1,3 +1,13 @@
+import type { Metadata } from "next";
+import { noIndexRobots } from "@/config/metadata";
+
+// Auth utility pages are deliberately excluded from the sitemap; mark them
+// noindex so crawlers agree with that choice (Ahrefs "Indexable page not in
+// sitemap", LAC-3521).
+export const metadata: Metadata = {
+  robots: noIndexRobots,
+};
+
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className="container grid place-items-center py-header">

--- a/src/app/(app)/(legal)/eula/page.mdx
+++ b/src/app/(app)/(legal)/eula/page.mdx
@@ -1,7 +1,6 @@
-export const metadata = {
-  title: "End User License Agreement",
-  description: "EULA for our software integrations. Read the license terms, restrictions, and your rights as a user.",
-}
+import { routeMetadata } from "@/config/metadata";
+
+export const metadata = routeMetadata.eula;
 
 # End User License Agreement (EULA) for Vercel Shipkit Integration
 

--- a/src/app/(app)/(legal)/privacy-policy/page.mdx
+++ b/src/app/(app)/(legal)/privacy-policy/page.mdx
@@ -1,7 +1,6 @@
-export const metadata = {
-  title: "Privacy Policy",
-  description: "How we handle your data. Our commitment to transparency, security, and your privacy rights.",
-}
+import { routeMetadata } from "@/config/metadata";
+
+export const metadata = routeMetadata.privacy;
 
 # Privacy Policy
 

--- a/src/app/(app)/(legal)/terms-of-service/page.mdx
+++ b/src/app/(app)/(legal)/terms-of-service/page.mdx
@@ -1,7 +1,6 @@
-export const metadata = {
-  title: "Terms of Service",
-  description: "Terms and conditions for using our services. Read our service agreement, usage policies, and your rights.",
-}
+import { routeMetadata } from "@/config/metadata";
+
+export const metadata = routeMetadata.terms;
 
 # Terms of Service
 

--- a/src/app/(app)/changelog/[...slug]/page.tsx
+++ b/src/app/(app)/changelog/[...slug]/page.tsx
@@ -6,8 +6,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
-import { constructMetadata } from "@/config/metadata";
-import { siteConfig } from "@/config/site-config";
+import { constructMetadata, routeMetadata } from "@/config/metadata";
 import { getChangelogEntries, getChangelogEntry } from "@/lib/changelog";
 import { cn } from "@/lib/utils";
 import { formatDate, formatDateTimeAttribute } from "@/lib/utils/format-date";
@@ -31,13 +30,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const entry = await getChangelogEntry(slug);
 
   if (!entry) {
-    return constructMetadata({
-      title: `Changelog | ${siteConfig.title}`,
-    });
+    return constructMetadata(routeMetadata.changelog);
   }
 
   return constructMetadata({
-    title: `${entry.title} | ${siteConfig.title} Changelog`,
+    title: `${entry.title} — Changelog`,
     description: entry.description,
   });
 }

--- a/src/app/(app)/changelog/page.tsx
+++ b/src/app/(app)/changelog/page.tsx
@@ -1,17 +1,13 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
-import { constructMetadata } from "@/config/metadata";
-import { siteConfig } from "@/config/site-config";
+import { constructMetadata, routeMetadata } from "@/config/metadata";
 import { getChangelogEntries } from "@/lib/changelog";
 import { formatDate } from "@/lib/utils/format-date";
 
 export const revalidate = 3600;
 
-export const metadata: Metadata = constructMetadata({
-  title: `Changelog | ${siteConfig.title}`,
-  description: `See what's new in ${siteConfig.title}. Latest updates, features, and fixes.`,
-});
+export const metadata: Metadata = constructMetadata(routeMetadata.changelog);
 
 export default async function ChangelogPage() {
   const entries = await getChangelogEntries();

--- a/src/app/(app)/contact/page.tsx
+++ b/src/app/(app)/contact/page.tsx
@@ -5,14 +5,11 @@ import { Link } from "@/components/primitives/link";
 import { Boxes } from "@/components/ui/background-boxes";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { constructMetadata } from "@/config/metadata";
+import { constructMetadata, routeMetadata } from "@/config/metadata";
 import { routes } from "@/config/routes";
 import { siteConfig } from "@/config/site-config";
 
-export const metadata: Metadata = constructMetadata({
-  title: "Contact Us",
-  description: `Get in touch with the ${siteConfig.name} team. We'd love to hear from you and answer any questions.`,
-});
+export const metadata: Metadata = constructMetadata(routeMetadata.contact);
 
 export default function ContactPage() {
   return (

--- a/src/app/(app)/faq/page.tsx
+++ b/src/app/(app)/faq/page.tsx
@@ -57,9 +57,9 @@ export default async function FaqPage() {
     <section className="container mx-auto mt-header space-y-section py-16">
       <div className="grid w-full grid-cols-1 md:grid-cols-5">
         <div className="z-10 col-span-2 bg-neutral-50 p-12 dark:bg-neutral-900">
-          <h2 className="mb-4 text-3xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">
+          <h1 className="mb-4 text-3xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">
             Frequently Asked Questions
-          </h2>
+          </h1>
           <p className="mb-8 text-neutral-600 dark:text-neutral-300">
             Here are some common questions about {siteConfig.title}. If you have any other
             questions, feel free to reach out to us.

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,8 +1,9 @@
 import { MetadataRoute } from "next";
 import { siteConfig } from "@/config/site-config";
 import { routes } from "@/config/routes";
+import { getChangelogEntries } from "@/lib/changelog";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = siteConfig.url;
 
   // Helper to check if a route is external
@@ -76,6 +77,19 @@ export default function sitemap(): MetadataRoute.Sitemap {
           ? 0.5
           : 0.8,
   }));
+
+  // Changelog entries are indexable pages linked from /changelog; without
+  // them Ahrefs flags "Indexable page not in sitemap" (LAC-3521). The helper
+  // returns [] if the GitHub API is unreachable, so the build never fails.
+  const changelogEntries = await getChangelogEntries();
+  for (const entry of changelogEntries) {
+    sitemapEntries.push({
+      url: `${baseUrl}/changelog/${entry.slug}`,
+      lastModified: entry.publishedAt ? new Date(entry.publishedAt) : new Date(),
+      changeFrequency: "monthly" as const,
+      priority: 0.5,
+    });
+  }
 
   // Sort by priority and then alphabetically
   sitemapEntries.sort((a, b) => {

--- a/src/components/footers/footer.tsx
+++ b/src/components/footers/footer.tsx
@@ -135,7 +135,7 @@ export const Footer: FC<FooterProps> = ({
               href={routes.home}
               className="text-4xl font-bold hover:text-primary/80 transition-colors"
             >
-              <h1>{siteConfig.name}</h1>
+              <span>{siteConfig.name}</span>
             </Link>
           </div>
           <div className="flex flex-col flex-wrap md:flex-row lg:gap-20">

--- a/src/config/metadata.ts
+++ b/src/config/metadata.ts
@@ -6,7 +6,9 @@ import { siteConfig } from "./site-config";
 const defaultOpenGraph: OpenGraph = {
 	type: "website",
 	locale: "en_US",
-	url: siteConfig.url,
+	// Resolves against metadataBase + the current route's pathname, exactly
+	// like alternates.canonical below, so og:url always matches the canonical.
+	url: "./",
 	title: siteConfig.title,
 	description: siteConfig.description,
 	siteName: siteConfig.name,
@@ -19,6 +21,10 @@ const defaultOpenGraph: OpenGraph = {
 		},
 	],
 };
+
+// Single owner of the noindex policy: used by constructMetadata's noIndex
+// flag and by segments (e.g. auth pages) that opt out of indexing wholesale.
+export const noIndexRobots = { index: false, follow: true } as const;
 
 const defaultTwitter: Twitter = {
 	card: "summary_large_image",
@@ -148,59 +154,67 @@ export const constructMetadata = ({
 		description: metadata.description ?? defaultTwitter.description,
 		images: images.length > 0 ? images : defaultTwitter.images,
 	},
-	robots: noIndex ? { index: false, follow: true } : defaultMetadata.robots,
+	robots: noIndex ? noIndexRobots : defaultMetadata.robots,
 });
 
-// Route-specific metadata for better CTR
+// Route-specific metadata for better CTR.
+// Titles omit the site name: the (app) layout's title template appends
+// `| ${siteConfig.name}` to child segments. Descriptions stay within the
+// 110-160 character range Ahrefs considers healthy (LAC-3521).
 export const routeMetadata = {
 	home: {
 		title: `${siteConfig.branding.projectName} - Free Open-Source Next.js SaaS Boilerplate`,
 		description:
-			`${siteConfig.branding.projectName} is a free, open-source Next.js starter kit with authentication, Shadcn UI, and one-click Vercel deploy. Ship production-ready React apps in minutes, not weeks.`,
+			`${siteConfig.branding.projectName} is a free, open-source Next.js starter kit with authentication, Shadcn UI, and one-click Vercel deploy. Ship production-ready React apps in minutes.`,
 	},
 	features: {
-		title: `Features - Modern App Development Made Simple | ${siteConfig.branding.projectName}`,
+		title: "Features - Modern App Development Made Simple",
 		description:
 			`Discover how ${siteConfig.branding.projectName} accelerates app development with Builder.io, Payload CMS, Auth.js, and more. Get enterprise-grade features without the complexity.`,
 	},
 	pricing: {
-		title: `Simple, Transparent Pricing | ${siteConfig.branding.projectName}`,
+		title: "Simple, Transparent Pricing",
 		description:
 			"Choose the perfect plan for your app. Start free, scale as you grow. All plans include core features, world-class support, and automatic updates.",
 	},
 	docs: {
-		title: `Documentation - Build Better Apps Faster | ${siteConfig.branding.projectName}`,
+		title: "Documentation - Build Better Apps Faster",
 		description:
 			`Comprehensive guides, API references, and examples to help you build production-ready apps with ${siteConfig.branding.projectName}. From quick starts to advanced topics.`,
 	},
 	faq: {
-		title: `FAQ - Frequently Asked Questions | ${siteConfig.branding.projectName}`,
+		title: "FAQ - Frequently Asked Questions",
 		description:
-			`Answers to common questions about ${siteConfig.branding.projectName}. Get help with setup, pricing, features, and more.`,
+			`Answers to common questions about ${siteConfig.branding.projectName} — setup, deployment, pricing, features, licensing, and support for your projects.`,
 	},
 	contact: {
-		title: `Contact Us | ${siteConfig.branding.projectName}`,
+		title: "Contact Us",
 		description:
-			`Get in touch with the ${siteConfig.branding.projectName} team. We're here to help with questions, feedback, and support.`,
+			`Get in touch with the ${siteConfig.branding.projectName} team. We are here to help with setup questions, feedback, bug reports, and support for your ${siteConfig.branding.projectName}-powered projects.`,
 	},
 	about: {
-		title: `About | ${siteConfig.branding.projectName}`,
+		title: "About",
 		description:
 			`Learn about ${siteConfig.branding.projectName}, our mission, and the team behind the platform. Building modern tools for developers who ship fast.`,
 	},
 	privacy: {
-		title: `Privacy Policy | ${siteConfig.branding.projectName}`,
+		title: "Privacy Policy",
 		description:
-			`How ${siteConfig.branding.projectName} handles your data. Our commitment to transparency, security, and your privacy rights.`,
+			`How ${siteConfig.branding.projectName} handles your data: what we collect, how we store it, and your rights. Our commitment to transparency, security, and your privacy.`,
 	},
 	terms: {
-		title: `Terms of Service | ${siteConfig.branding.projectName}`,
+		title: "Terms of Service",
 		description:
-			`Terms and conditions for using ${siteConfig.branding.projectName}. Read our service agreement, usage policies, and your rights.`,
+			`Terms and conditions for using ${siteConfig.branding.projectName}. Read our service agreement, acceptable use policies, disclaimers, and your rights and responsibilities.`,
+	},
+	eula: {
+		title: "End User License Agreement",
+		description:
+			"End User License Agreement for the Vercel Shipkit integration. Read the license terms, restrictions, and your rights as a user of the integration.",
 	},
 	changelog: {
-		title: `Changelog | ${siteConfig.branding.projectName}`,
+		title: "Changelog",
 		description:
-			`Latest updates, improvements, and releases for ${siteConfig.branding.projectName}. See what's new and what's coming next.`,
+			`Latest updates, improvements, and releases for ${siteConfig.branding.projectName}. Follow new features, bug fixes, and breaking changes as we ship them.`,
 	},
 };

--- a/tests/unit/seo-internal-links.test.ts
+++ b/tests/unit/seo-internal-links.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import sitemap from "@/app/sitemap";
 import { defaultFooterGroups } from "@/components/footers/footer";
 import { defaultNavLinks } from "@/config/navigation";
@@ -14,8 +14,18 @@ import { siteConfig } from "@/config/site-config";
  * must never be emitted in the sitemap.
  */
 
-const sitemapPaths = () =>
-	sitemap().map((entry) => new URL(entry.url).pathname.replace(/\/$/, "") || "/");
+// The sitemap pulls changelog entries from the GitHub API (LAC-3521);
+// stub the fields it reads so unit tests stay offline and deterministic.
+vi.mock("@/lib/changelog", () => ({
+	getChangelogEntries: async () => [
+		{ slug: "1.2.3", publishedAt: "2026-01-01T00:00:00.000Z" },
+	],
+}));
+
+// Built once and shared: the sitemap is identical across tests.
+const sitemapEntries = sitemap();
+const sitemapPaths = async () =>
+	(await sitemapEntries).map((entry) => new URL(entry.url).pathname.replace(/\/$/, "") || "/");
 
 const chromeHrefs = () => {
 	const footerHrefs = defaultFooterGroups.flatMap((element) => {
@@ -31,24 +41,36 @@ const chromeHrefs = () => {
 };
 
 describe("sitemap hygiene (LAC-2783)", () => {
-	it("does not include routes that have no page", () => {
-		const paths = sitemapPaths();
+	it("does not include routes that have no page", async () => {
+		const paths = await sitemapPaths();
 		expect(paths).not.toContain("/docs"); // planned route, never implemented
 		expect(paths).not.toContain("/v1"); // CLI logger API endpoint, not a page
 		expect(paths).not.toContain("/trpc"); // demo page, should not be indexed
 	});
 
-	it("uses the production site url", () => {
-		for (const entry of sitemap()) {
+	it("uses the production site url", async () => {
+		for (const entry of await sitemapEntries) {
 			expect(entry.url.startsWith(siteConfig.url)).toBe(true);
 		}
+	});
+
+	it("includes changelog entry pages (LAC-3521)", async () => {
+		// Changelog entries are indexable and linked from /changelog; leaving
+		// them out trips Ahrefs "Indexable page not in sitemap".
+		expect(await sitemapPaths()).toContain("/changelog/1.2.3");
 	});
 });
 
 describe("no orphan pages (LAC-2783)", () => {
-	it("links every sitemap URL from the header nav or footer", () => {
+	it("links every sitemap URL from the header nav or footer", async () => {
 		const links = chromeHrefs();
-		const orphans = sitemapPaths().filter((path) => path !== "/" && !links.has(path));
+		const orphans = (await sitemapPaths()).filter(
+			(path) =>
+				path !== "/" &&
+				// Changelog entries are linked from the /changelog index, not the chrome.
+				!path.startsWith("/changelog/") &&
+				!links.has(path),
+		);
 		expect(orphans).toEqual([]);
 	});
 });

--- a/tests/unit/seo-meta-tags.test.ts
+++ b/tests/unit/seo-meta-tags.test.ts
@@ -1,0 +1,77 @@
+import { render } from "@testing-library/react";
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
+import { metadata as authLayoutMetadata } from "@/app/(app)/(authentication)/layout";
+import { Footer } from "@/components/footers/footer";
+import {
+	constructMetadata,
+	defaultMetadata,
+	noIndexRobots,
+	routeMetadata,
+} from "@/config/metadata";
+import { siteConfig } from "@/config/site-config";
+
+/**
+ * Regression tests for LAC-3521: Ahrefs site audit on bones.sh reported
+ * "Open Graph URL not matching canonical" (og:url was hardcoded to the site
+ * root on every page), "Multiple H1 tags" (the footer rendered the site name
+ * as an <h1> on every page), and meta descriptions outside the 110–160
+ * character range Ahrefs considers healthy.
+ */
+
+// Ahrefs flags descriptions shorter than 110 or longer than 160 characters.
+const DESCRIPTION_MIN = 110;
+const DESCRIPTION_MAX = 160;
+
+describe("og:url matches canonical (LAC-3521)", () => {
+	it("derives og:url per-page the same way as the canonical URL", () => {
+		// "./" resolves against metadataBase + the current route's pathname,
+		// so og:url and canonical stay identical on every page.
+		expect(defaultMetadata.alternates?.canonical).toBe("./");
+		expect(defaultMetadata.openGraph?.url).toBe("./");
+		expect(constructMetadata({ title: "Anything" }).openGraph?.url).toBe("./");
+	});
+});
+
+describe("single H1 per page (LAC-3521)", () => {
+	it("does not render the site name in the footer as an <h1>", () => {
+		const { container } = render(createElement(Footer));
+		expect(container.querySelector("h1")).toBeNull();
+	});
+});
+
+describe("meta description lengths (LAC-3521)", () => {
+	it("keeps every routeMetadata description between 110 and 160 characters", () => {
+		// routeMetadata is the single source for page descriptions, including
+		// the legal MDX pages, which import their metadata from it.
+		for (const [route, metadata] of Object.entries(routeMetadata)) {
+			const description = metadata.description ?? "";
+			expect
+				.soft(description.length, `${route} description is ${description.length} chars`)
+				.toBeGreaterThanOrEqual(DESCRIPTION_MIN);
+			expect
+				.soft(description.length, `${route} description is ${description.length} chars`)
+				.toBeLessThanOrEqual(DESCRIPTION_MAX);
+		}
+	});
+});
+
+describe("auth pages are noindex (LAC-3521)", () => {
+	it("marks the authentication segment noindex to match its sitemap exclusion", () => {
+		expect(authLayoutMetadata.robots).toBe(noIndexRobots);
+	});
+});
+
+describe("route titles rely on the layout title template (LAC-3521)", () => {
+	it("does not hardcode the site name suffix that the template already appends", () => {
+		// The (app) layout applies `%s | Bones` to child segments, so a manual
+		// suffix renders as "About | Bones | Bones". The home page is exempt:
+		// title.template does not apply to the segment that defines it.
+		for (const [route, metadata] of Object.entries(routeMetadata)) {
+			if (route === "home") continue;
+			expect
+				.soft(metadata.title, `${route} title duplicates the template suffix`)
+				.not.toMatch(new RegExp(`\\|\\s*${siteConfig.branding.projectName}\\s*$`));
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the actionable findings from the Ahrefs site audit of bones.sh ([LAC-3521](https://paperclip.dev/LAC/issues/LAC-3521)).

### Open Graph URL not matching canonical (13 URLs)
`defaultOpenGraph.url` was hardcoded to the site root, so every page shipped `og:url = https://bones.sh` while the canonical resolved per-page. It is now `"./"`, which resolves against `metadataBase` + the current pathname exactly like `alternates.canonical` — og:url and canonical are now identical on every page.

### Multiple H1 tags (11 URLs)
The footer rendered the site name as an `<h1>` on every page (twice on /changelog, which renders two footers — see follow-up below). Demoted to a `<span>`. The FAQ page had no H1 of its own, so its `<h2>` heading is promoted to `<h1>`. Every page now renders exactly one H1 (verified in the local prerender output).

### Meta descriptions too short (4+ URLs) / too long (1 URL)
All served descriptions normalized into the 110–160 character range Ahrefs considers healthy: home (was 165), changelog (82), contact (91), faq (90), eula (100), privacy-policy (91), terms-of-service (105). The legal MDX pages now single-source their metadata from `routeMetadata` instead of carrying inline copies.

### Indexable page not in sitemap (2 URLs)
- Changelog entry pages (indexable, linked from /changelog) are now emitted in the sitemap. `getChangelogEntries` returns `[]` on GitHub API failure, so the build never breaks.
- Auth utility pages (sign-in/sign-up/forgot-password/sign-out/error) were indexable while deliberately excluded from the sitemap — the authentication segment is now `noindex, follow`.

### Adjacent fixes in the same helper
- `routeMetadata` titles no longer hardcode the `| Bones` suffix the layout title template already appends (was rendering "About | Bones | Bones").
- Changelog pages stop interpolating `siteConfig.title` ("Launch your app today") into titles/descriptions — "See what's new in Launch your app today" is gone.
- `noIndexRobots` exported from the metadata helper as the single owner of the noindex policy.

### Intentionally not touched
- 3XX redirect / HTTP→HTTPS / redirect chain findings: no link in our markup redirects and none use `http://` — these are inbound/external URLs, per ticket scope.
- "Page has only one dofollow incoming internal link" — notice-level internal linking telemetry.

## Acceptance criteria
- [x] og:url derived from canonical on every page (verified in prerendered build output)
- [x] Exactly one `<h1>` per page
- [x] Meta descriptions within 110–160 chars
- [x] Changelog entries in sitemap; auth pages noindex

## Testing
- New regression tests in `tests/unit/seo-meta-tags.test.ts` (og:url/canonical, footer H1, description lengths, title-template suffix, auth noindex); updated `tests/unit/seo-internal-links.test.ts` for the async sitemap with a mocked changelog feed. All were red on the old code, all green now (`pnpm test`: 3 files, 10 tests).
- `tsc --noEmit` clean; `pnpm build` clean — verified og:url/canonical/robots/H1 counts/description lengths directly in the prerendered HTML for /, /about, /faq, /changelog, /contact, /eula, /privacy-policy, /terms-of-service, /sign-in.
- Note: local build emits no changelog sitemap entries because the changelog source repo is private and the GitHub API is unauthenticated locally; on Vercel `GITHUB_TOKEN` is set — verify on the preview deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)