### PR TITLE
fix(layout): remove duplicate header/footer on /changelog (LAC-3539)

### DIFF
--- a/src/app/(app)/changelog/layout.tsx
+++ b/src/app/(app)/changelog/layout.tsx
@@ -1,13 +1,9 @@
 import type { ReactNode } from "react";
-import { Header } from "@/components/headers/header";
-import MainLayout from "@/components/layouts/main-layout";
 
 export default function ChangelogLayout({ children }: { children: ReactNode }) {
   return (
-    <MainLayout header={<Header variant="minimal" />} footer={null}>
-      <div className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
-        {children}
-      </div>
-    </MainLayout>
+    <div className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      {children}
+    </div>
   );
 }

--- a/src/components/layouts/main-layout.tsx
+++ b/src/components/layouts/main-layout.tsx
@@ -10,16 +10,16 @@ export default function MainLayout({
 	footer,
 }: {
 	children: React.ReactNode;
-	header?: React.ReactNode;
-	footer?: React.ReactNode;
+	header?: React.ReactNode | null;
+	footer?: React.ReactNode | null;
 	className?: string;
 }) {
 	return (
 		<>
 			<div className={cn("", className)}>
-				{header ?? <Header />}
+				{header === undefined ? <Header /> : header}
 				{children}
-				{footer ?? <Footer />}
+				{footer === undefined ? <Footer /> : footer}
 			</div>
 		</>
 	);


### PR DESCRIPTION
## Summary
- Remove nested `MainLayout` from changelog layout — the parent `(app)/layout.tsx` already provides one, so `/changelog` was rendering 3 headers and 2 footers
- Fix `MainLayout` prop handling: `??` treats `null` as nullish (renders default), changed to explicit `undefined` check so `null` means "render nothing" — fixes the API for all callers

## Test plan
- [ ] `curl -sL https://bones.sh/changelog | python3 -c "import sys,re; html=sys.stdin.read(); print(f'headers:{len(re.findall(r\"<header[\\s>]\",html))} footers:{len(re.findall(r\"<footer[\\s>]\",html))}')"` → should be 1/1
- [ ] Verify /changelog page visually — standard site header, footer, content centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)