### PR TITLE
fix(changelog): point source at public shipkit-io/bones repo (LAC-3540)

### DIFF
--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -30,8 +30,8 @@ interface GitHubTag {
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
-const REPO_OWNER = process.env.GITHUB_REPO_OWNER ?? "lacymorrow";
-const REPO_NAME = process.env.GITHUB_REPO_NAME ?? "shipkit";
+const REPO_OWNER = process.env.GITHUB_REPO_OWNER ?? "shipkit-io";
+const REPO_NAME = process.env.GITHUB_REPO_NAME ?? "bones";
 const GITHUB_API = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}`;
 const COMMITS_PER_PAGE = 100;
 const MAX_PAGES = 5; // 500 commits max


### PR DESCRIPTION
## Summary
- Change changelog default source from `lacymorrow/shipkit` (private, 404 without token) to `shipkit-io/bones` (public)
- This is why bones.sh/changelog shows zero entries in production — no `GITHUB_TOKEN` in Vercel env, and the default repo is inaccessible

## Test plan
- [ ] Verify `https://api.github.com/repos/shipkit-io/bones/commits?per_page=1` returns 200 (confirmed)
- [ ] After merge + deploy, check `https://bones.sh/changelog` shows entries
- [ ] Verify sitemap includes `/changelog/<slug>` URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)