### PR TITLE
fix(ci): fix claude.yml YAML parse error causing 0s failures (LAC-3541)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,7 +31,8 @@ jobs:
     steps:
       - name: Skip if Claude OAuth not configured
         if: env.CLAUDE_ACCESS_TOKEN == '' || env.CLAUDE_REFRESH_TOKEN == '' || env.CLAUDE_EXPIRES_AT == ''
-        run: echo 'Skipping Claude PR Assistant: Claude OAuth secrets not set'
+        run: |
+          echo 'Skipping Claude PR Assistant - Claude OAuth secrets not set'
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- The colon in `echo 'Skipping Claude PR Assistant: Claude OAuth secrets not set'` caused a YAML parse error ("mapping values not allowed in this context")
- GitHub couldn't compile the workflow, so it registered a 0-second failure run on every push event — even though the workflow has no `push` trigger
- Fix: switch to block scalar (`run: |`) to avoid the colon-space YAML ambiguity
- Verified clean with `actionlint`

## Test plan
- [ ] After merge, push to any branch and verify claude.yml no longer shows a 0s failure in `gh run list --workflow claude.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)