### PR TITLE
feat: add daily contact-form health check (LAC-3572)

### DIFF
--- a/.github/workflows/contact-form-healthcheck.yml
+++ b/.github/workflows/contact-form-healthcheck.yml
@@ -1,0 +1,63 @@
+name: Contact form health check
+
+# LAC-3572 (part of LAC-3570): verify the contact form's dependencies every day
+# so it can never silently break again. Two layers:
+#   1. GET /api/health/contact — confirms RESEND_API_KEY is set and still valid
+#      (lightweight authenticated Resend read) and siteConfig email addresses
+#      are configured. Sends no email.
+#   2. GET /contact — confirms the page carrying the form is deployed and
+#      serving 200 on the canonical domain. (The form submits via a Next.js
+#      server action, which has no stable REST route to probe, so the health
+#      endpoint above is the primary layer.)
+# If either fails the job fails, and GitHub emails the repo owner. Add a Slack
+# webhook secret (SLACK_WEBHOOK_URL) to also get a chat alert.
+
+on:
+  schedule:
+    - cron: '0 13 * * *' # 13:00 UTC daily (~9am ET)
+  workflow_dispatch: {} # allow manual runs
+
+jobs:
+  healthcheck:
+    runs-on: ubuntu-latest
+    env:
+      SITE_URL: https://bones.sh
+      HEALTHCHECK_TOKEN: ${{ secrets.HEALTHCHECK_TOKEN }}
+    steps:
+      - name: Config health check (Resend credentials + email config)
+        run: |
+          echo "GET $SITE_URL/api/health/contact"
+          code=$(curl -s -o /tmp/health.json -w "%{http_code}" \
+            -H "x-healthcheck-token: $HEALTHCHECK_TOKEN" \
+            "$SITE_URL/api/health/contact")
+          echo "HTTP $code"; cat /tmp/health.json; echo
+          if [ "$code" != "200" ]; then
+            echo "::error::Contact form health check FAILED (HTTP $code). Email provider may be misconfigured."
+            exit 1
+          fi
+          # The site serves 200 HTML for unknown routes (CMS catch-all), so a
+          # status code alone can't prove the health route is deployed —
+          # require the endpoint's JSON body too.
+          if ! grep -q '"ok":\s*true' /tmp/health.json; then
+            echo "::error::Health endpoint did not return its JSON body — route may not be deployed (catch-all page served instead)."
+            exit 1
+          fi
+
+      - name: Contact page check (form is deployed and serving)
+        run: |
+          echo "GET $SITE_URL/contact"
+          code=$(curl -sL -o /dev/null -w "%{http_code}" "$SITE_URL/contact")
+          echo "HTTP $code"
+          if [ "$code" != "200" ]; then
+            echo "::error::Contact page is DOWN (HTTP $code)."
+            exit 1
+          fi
+
+      - name: Notify Slack on failure
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d '{"text":":rotating_light: bones.sh contact form health check FAILED. See GitHub Actions run '"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"'"}' || true

--- a/src/app/(app)/api/health/contact/route.ts
+++ b/src/app/(app)/api/health/contact/route.ts
@@ -1,0 +1,116 @@
+import { siteConfig } from "@/config/site-config";
+
+/**
+ * Contact-form health check (LAC-3572, part of LAC-3570).
+ *
+ * Verifies the configuration that historically takes the contact form down —
+ * a missing/revoked RESEND_API_KEY or a missing from/to address — WITHOUT
+ * sending a real email. A daily CI job (see
+ * .github/workflows/contact-form-healthcheck.yml) hits this endpoint so the
+ * form can't silently break again.
+ *
+ * The contact form submits via the `submitContactForm` server action, which
+ * has no stable REST surface to probe, so this endpoint is the primary
+ * monitoring layer: it validates the same inputs the action depends on
+ * (Resend credentials + siteConfig.email addresses).
+ *
+ * Optionally gated by HEALTHCHECK_TOKEN: if set, callers must pass ?token=...
+ * or an "x-healthcheck-token" header. If unset, the endpoint is open (so
+ * monitoring keeps working even before the token exists).
+ */
+
+export const dynamic = "force-dynamic";
+
+const RESEND_DOMAINS_URL = "https://api.resend.com/domains";
+
+interface HealthCheck {
+	name: string;
+	ok: boolean;
+	detail: string;
+}
+
+const isAuthorized = (request: Request): boolean => {
+	const expected = process.env.HEALTHCHECK_TOKEN;
+	if (!expected) return true; // no token configured -> open
+	const provided =
+		request.headers.get("x-healthcheck-token") ?? new URL(request.url).searchParams.get("token");
+	return provided === expected;
+};
+
+/**
+ * Confirms the Resend API key is present AND actually valid, by making a
+ * lightweight authenticated read (listing domains). No email is sent.
+ */
+const checkResend = async (): Promise<HealthCheck> => {
+	const key = process.env.RESEND_API_KEY;
+	if (!key) {
+		return { name: "resend_api_key", ok: false, detail: "RESEND_API_KEY not set" };
+	}
+
+	try {
+		const response = await fetch(RESEND_DOMAINS_URL, {
+			headers: { Authorization: `Bearer ${key}` },
+			cache: "no-store",
+		});
+		if (!response.ok) {
+			// Sending-only keys can't list domains, but the rejection proves the
+			// key authenticated — Resend names it "restricted_api_key". That key
+			// still sends mail, so the form is healthy.
+			const body = (await response.json().catch(() => null)) as {
+				name?: string;
+				message?: string;
+			} | null;
+			if (body?.name === "restricted_api_key" || body?.message?.includes("restricted")) {
+				return { name: "resend_api_key", ok: true, detail: "valid (sending-only key)" };
+			}
+			if (response.status === 400 || response.status === 401 || response.status === 403) {
+				return {
+					name: "resend_api_key",
+					ok: false,
+					detail: `Resend rejected key (HTTP ${response.status}): ${body?.message ?? "unknown"}`,
+				};
+			}
+			return {
+				name: "resend_api_key",
+				ok: false,
+				detail: `Resend API unhealthy (HTTP ${response.status})`,
+			};
+		}
+		return { name: "resend_api_key", ok: true, detail: "valid" };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return { name: "resend_api_key", ok: false, detail: `Resend request failed: ${message}` };
+	}
+};
+
+export async function GET(request: Request): Promise<Response> {
+	if (!isAuthorized(request)) {
+		return Response.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+	}
+
+	const checks: HealthCheck[] = [
+		// The server action sends to siteConfig.email.support from .noreply —
+		// both must be non-empty for delivery to work.
+		{
+			name: "support_email",
+			ok: Boolean(siteConfig.email?.support),
+			detail: siteConfig.email?.support ? "set" : "siteConfig.email.support not set",
+		},
+		{
+			name: "noreply_email",
+			ok: Boolean(siteConfig.email?.noreply),
+			detail: siteConfig.email?.noreply ? "set" : "siteConfig.email.noreply not set",
+		},
+		await checkResend(),
+	];
+
+	const ok = checks.every((check) => check.ok);
+	return Response.json(
+		{ ok, checks },
+		{
+			status: ok ? 200 : 503,
+			// Disable caching so monitors always see live state.
+			headers: { "Cache-Control": "no-store, max-age=0" },
+		}
+	);
+}

--- a/tests/node/api/health-contact.test.ts
+++ b/tests/node/api/health-contact.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "@/app/(app)/api/health/contact/route";
+
+const HEALTH_URL = "https://example.com/api/health/contact";
+
+const makeRequest = (init?: { token?: string; query?: string }) =>
+	new Request(`${HEALTH_URL}${init?.query ?? ""}`, {
+		headers: init?.token ? { "x-healthcheck-token": init.token } : undefined,
+	});
+
+const mockResendResponse = (status: number) =>
+	vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status }));
+
+describe("GET /api/health/contact", () => {
+	const originalEnv = { ...process.env };
+
+	beforeEach(() => {
+		delete process.env.HEALTHCHECK_TOKEN;
+		process.env.RESEND_API_KEY = "re_test_key";
+	});
+
+	afterEach(() => {
+		process.env = { ...originalEnv };
+		vi.restoreAllMocks();
+	});
+
+	it("returns 200 with all checks passing when Resend accepts the key", async () => {
+		const fetchSpy = mockResendResponse(200);
+
+		const res = await GET(makeRequest());
+		const body = await res.json();
+
+		expect(res.status).toBe(200);
+		expect(body.ok).toBe(true);
+		expect(body.checks.every((c: { ok: boolean }) => c.ok)).toBe(true);
+		expect(res.headers.get("cache-control")).toContain("no-store");
+		expect(fetchSpy).toHaveBeenCalledWith(
+			"https://api.resend.com/domains",
+			expect.objectContaining({
+				headers: { Authorization: "Bearer re_test_key" },
+			})
+		);
+	});
+
+	it("returns 503 when RESEND_API_KEY is not set", async () => {
+		delete process.env.RESEND_API_KEY;
+
+		const res = await GET(makeRequest());
+		const body = await res.json();
+
+		expect(res.status).toBe(503);
+		expect(body.ok).toBe(false);
+		const keyCheck = body.checks.find((c: { name: string }) => c.name === "resend_api_key");
+		expect(keyCheck.ok).toBe(false);
+	});
+
+	it("returns 503 when Resend rejects the key", async () => {
+		mockResendResponse(401);
+
+		const res = await GET(makeRequest());
+		const body = await res.json();
+
+		expect(res.status).toBe(503);
+		expect(body.ok).toBe(false);
+	});
+
+	it("returns 200 for a valid sending-only (restricted) key", async () => {
+		// Resend rejects /domains for send-only keys with name "restricted_api_key",
+		// but such a key is valid for sending — the form is healthy.
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					statusCode: 401,
+					message: "This API key is restricted to only send emails",
+					name: "restricted_api_key",
+				}),
+				{ status: 401 }
+			)
+		);
+
+		const res = await GET(makeRequest());
+		const body = await res.json();
+
+		expect(res.status).toBe(200);
+		expect(body.ok).toBe(true);
+	});
+
+	it("returns 503 for an invalid key (Resend HTTP 400)", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					statusCode: 400,
+					message: "API key is invalid",
+					name: "validation_error",
+				}),
+				{ status: 400 }
+			)
+		);
+
+		const res = await GET(makeRequest());
+		const body = await res.json();
+
+		expect(res.status).toBe(503);
+		expect(body.ok).toBe(false);
+	});
+
+	it("returns 503 when the Resend request throws", async () => {
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+
+		const res = await GET(makeRequest());
+
+		expect(res.status).toBe(503);
+	});
+
+	it("verifies siteConfig support and noreply emails are configured", async () => {
+		mockResendResponse(200);
+
+		const res = await GET(makeRequest());
+		const body = await res.json();
+
+		const names = body.checks.map((c: { name: string }) => c.name);
+		expect(names).toContain("support_email");
+		expect(names).toContain("noreply_email");
+	});
+
+	describe("HEALTHCHECK_TOKEN gate", () => {
+		beforeEach(() => {
+			process.env.HEALTHCHECK_TOKEN = "s3cret";
+		});
+
+		it("rejects requests without the token", async () => {
+			const res = await GET(makeRequest());
+			expect(res.status).toBe(401);
+		});
+
+		it("accepts the token via header", async () => {
+			mockResendResponse(200);
+			const res = await GET(makeRequest({ token: "s3cret" }));
+			expect(res.status).toBe(200);
+		});
+
+		it("accepts the token via query param", async () => {
+			mockResendResponse(200);
+			const res = await GET(makeRequest({ query: "?token=s3cret" }));
+			expect(res.status).toBe(200);
+		});
+
+		it("rejects a wrong token", async () => {
+			const res = await GET(makeRequest({ token: "wrong" }));
+			expect(res.status).toBe(401);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
Part of Paperclip **LAC-3572** (parent LAC-3570) — contact-form monitoring rollout across ShipKit downstreams; same pattern as shipkit-www#69/#70.

- **`GET /api/health/contact`** — verifies `RESEND_API_KEY` is set **and valid** via a lightweight authenticated Resend read (`GET /domains`, no email sent; sending-only restricted keys count as healthy) and that `siteConfig.email.support`/`noreply` are configured. 200 healthy / 503 unhealthy, `Cache-Control: no-store`, optional `HEALTHCHECK_TOKEN` gate (already provisioned: Vercel prod env + GH Actions secret).
- **`.github/workflows/contact-form-healthcheck.yml`** — daily 13:00 UTC cron against **https://bones.sh**: asserts the health endpoint's JSON body (`"ok": true`, not just HTTP 200, so a catch-all page can't false-pass) plus a `/contact` page check.

This lands the pattern in the FREE bones template, so future downstreams inherit it. bones now deploys bones.sh directly (the bones-www Vercel project no longer exists).

## Acceptance criteria
- Health endpoint returns 200 only when Resend credentials + email config are valid; 503 otherwise; no email is ever sent.
- Daily workflow fails (and emails the repo owner) when the contact form's dependencies break.

## Testing
`bunx vitest run --config vitest.config.node.ts tests/node/api/health-contact.test.ts` — **11/11 pass** locally.

⚠️ Note: this Vercel project currently has **no `RESEND_API_KEY` in production** — the daily workflow will correctly FAIL until a key is provisioned (tracked with the owner in LAC-3578). That is the monitoring working as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)